### PR TITLE
게임 전적데이터 리스트 반환 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,7 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation group: 'org.springframework.boot', name: 'spring-boot-starter-jdbc'
+    implementation group: 'org.springframework.boot', name: 'spring-boot-starter-validation'
     implementation group: 'org.mariadb.jdbc', name: 'mariadb-java-client', version: '3.0.6'
     implementation group: 'org.mybatis.spring.boot', name: 'mybatis-spring-boot-starter', version: '2.2.2'
     implementation group: 'org.springframework.boot', name: 'spring-boot-starter-data-redis'

--- a/src/main/java/com/nooblol/account/controller/MatchGameController.java
+++ b/src/main/java/com/nooblol/account/controller/MatchGameController.java
@@ -24,11 +24,13 @@ public class MatchGameController {
   private final MatchGameInfoService matchGameInfoService;
 
   /**
-   * 전적항목을 간단하게 표현함에 있어서 필요한 정보만 Return 한다. PUUID사용자의 가장최근 진행한 게임순으로 순차가 이뤄지며, 같이 참여한
+   * Puuid를 요청한 사용자의
    *
-   * @param puuid
-   * @param sync
-   * @param pageNum
+   * @param puuid    Summoner_Account의 puuid컬럼값으로, 해당 파라미터를 통해 해당 유저의 최근 전적데이터를 Return한다
+   * @param sync     해당값은 Default로 false를 Riot과 통신하여 최근 전적 데이터를 DB로 삽입한 이후 전적 데이터를 Return하며, True인
+   *                 경우 Riot서버와 추가적인 통신 없이, DB데이터를 바로 RETURN하며,
+   * @param pageNum  Default Value는 0으로, 0은 최근전적 Row 0~29경기, 1은 Row 30~59경기까지를 Return하게 된다.
+   * @param limitNum Default Value는 30으로 한번 조회에 몇건의 전적을 가져갈지를 설정하는 Parameter
    * @return
    * @throws Exception
    */

--- a/src/main/java/com/nooblol/account/controller/MatchGameController.java
+++ b/src/main/java/com/nooblol/account/controller/MatchGameController.java
@@ -24,7 +24,7 @@ public class MatchGameController {
   private final MatchGameInfoService matchGameInfoService;
 
   /**
-   * Puuid를 요청한 사용자의
+   * Puuid를 요청한 사용자의 최근 전적 조회
    *
    * @param puuid    Summoner_Account의 puuid컬럼값으로, 해당 파라미터를 통해 해당 유저의 최근 전적데이터를 Return한다
    * @param sync     해당값은 Default로 false를 Riot과 통신하여 최근 전적 데이터를 DB로 삽입한 이후 전적 데이터를 Return하며, True인
@@ -34,8 +34,9 @@ public class MatchGameController {
    * @return
    * @throws Exception
    */
-  @GetMapping("/simplelist")
-  public ResponseDto selectMatchList(@RequestParam("puuid") String puuid,
+  @GetMapping("/list")
+  public ResponseDto selectMatchList(
+      @RequestParam(value = "puuid", required = false) @NotBlank String puuid,
       @RequestParam(value = "sync", required = false) boolean sync,
       @RequestParam(value = "page", defaultValue = "0") int pageNum) throws Exception {
     pageNum = pageNum * 30;

--- a/src/main/java/com/nooblol/account/controller/MatchGameController.java
+++ b/src/main/java/com/nooblol/account/controller/MatchGameController.java
@@ -1,9 +1,13 @@
 package com.nooblol.account.controller;
 
+import com.nooblol.account.service.MatchGameInfoService;
+import com.nooblol.global.dto.ResponseDto;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 /**
@@ -17,5 +21,29 @@ public class MatchGameController {
 
   private final Logger log = LoggerFactory.getLogger(getClass());
 
+  private final MatchGameInfoService matchGameInfoService;
+
+  /**
+   * 전적항목을 간단하게 표현함에 있어서 필요한 정보만 Return 한다.
+   * PUUID사용자의 가장최근 진행한 게임순으로 순차가 이뤄지며, 같이 참여한
+   * @param puuid
+   * @param sync
+   * @param pageNum
+   * @return
+   * @throws Exception
+   */
+  @GetMapping("/simplelist")
+  public ResponseDto selectMatchList(@RequestParam("puuid") String puuid,
+      @RequestParam(value = "sync", required = false) boolean sync,
+      @RequestParam(value = "page", defaultValue = "0") int pageNum) throws Exception {
+    ResponseDto rtnData = null;
+    pageNum = pageNum * 30;
+
+    if (sync) {
+      return matchGameInfoService.getMatchInfoListByPuuid(puuid, pageNum);
+    }
+
+    return matchGameInfoService.syncRiotToDbByPuuidAfterGetMatchSimpleList(puuid, pageNum);
+  }
 
 }

--- a/src/main/java/com/nooblol/account/controller/MatchGameController.java
+++ b/src/main/java/com/nooblol/account/controller/MatchGameController.java
@@ -24,8 +24,8 @@ public class MatchGameController {
   private final MatchGameInfoService matchGameInfoService;
 
   /**
-   * 전적항목을 간단하게 표현함에 있어서 필요한 정보만 Return 한다.
-   * PUUID사용자의 가장최근 진행한 게임순으로 순차가 이뤄지며, 같이 참여한
+   * 전적항목을 간단하게 표현함에 있어서 필요한 정보만 Return 한다. PUUID사용자의 가장최근 진행한 게임순으로 순차가 이뤄지며, 같이 참여한
+   *
    * @param puuid
    * @param sync
    * @param pageNum
@@ -36,9 +36,7 @@ public class MatchGameController {
   public ResponseDto selectMatchList(@RequestParam("puuid") String puuid,
       @RequestParam(value = "sync", required = false) boolean sync,
       @RequestParam(value = "page", defaultValue = "0") int pageNum) throws Exception {
-    ResponseDto rtnData = null;
     pageNum = pageNum * 30;
-
     if (sync) {
       return matchGameInfoService.getMatchInfoListByPuuid(puuid, pageNum);
     }

--- a/src/main/java/com/nooblol/account/controller/MatchGameController.java
+++ b/src/main/java/com/nooblol/account/controller/MatchGameController.java
@@ -2,9 +2,11 @@ package com.nooblol.account.controller;
 
 import com.nooblol.account.service.MatchGameInfoService;
 import com.nooblol.global.dto.ResponseDto;
+import javax.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -17,6 +19,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/match")
 @RequiredArgsConstructor
+@Validated
 public class MatchGameController {
 
   private final Logger log = LoggerFactory.getLogger(getClass());
@@ -38,13 +41,16 @@ public class MatchGameController {
   public ResponseDto selectMatchList(
       @RequestParam(value = "puuid", required = false) @NotBlank String puuid,
       @RequestParam(value = "sync", required = false) boolean sync,
-      @RequestParam(value = "page", defaultValue = "0") int pageNum) throws Exception {
+      @RequestParam(value = "page", defaultValue = "0") int pageNum,
+      @RequestParam(value = "limit", defaultValue = "30") int limitNum
+  ) throws Exception {
     pageNum = pageNum * 30;
     if (sync) {
-      return matchGameInfoService.getMatchInfoListByPuuid(puuid, pageNum);
+      return matchGameInfoService.getMatchInfoListByPuuid(puuid, pageNum, limitNum);
     }
 
-    return matchGameInfoService.syncRiotToDbByPuuidAfterGetMatchSimpleList(puuid, pageNum);
+    return matchGameInfoService.syncRiotToDbByPuuidAfterGetMatchSimpleList(puuid, pageNum,
+        limitNum);
   }
 
 }

--- a/src/main/java/com/nooblol/account/dto/match/MatchGameParticipantsDto.java
+++ b/src/main/java/com/nooblol/account/dto/match/MatchGameParticipantsDto.java
@@ -1,5 +1,6 @@
 package com.nooblol.account.dto.match;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -11,6 +12,7 @@ import lombok.Setter;
 @Getter
 @Setter
 @NoArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class MatchGameParticipantsDto {
 
   private String puuid;

--- a/src/main/java/com/nooblol/account/dto/match/MatchGameSimpleDto.java
+++ b/src/main/java/com/nooblol/account/dto/match/MatchGameSimpleDto.java
@@ -1,0 +1,47 @@
+package com.nooblol.account.dto.match;
+
+import java.util.List;
+import lombok.Getter;
+import lombok.Setter;
+
+//간단한 전적 반환
+@Getter
+@Setter
+public class MatchGameSimpleDto {
+
+  private String puuid;
+
+  private String summonerId;
+  private String summonerName;
+  private String championName;
+  private int championId;
+
+  private String role;
+  private String lane;
+  private int teamId;
+  private String teamPosition;
+  private boolean win;
+
+  private int kills;
+  private int deaths;
+  private int assists;
+
+  private int summoner1Id;
+  private int summoner2Id;
+
+  private int item0;
+  private int item1;
+  private int item2;
+  private int item3;
+  private int item4;
+  private int item5;
+  private int item6;
+
+  private long gameCreation;
+  private long gameDuration;
+
+
+  private int queueId;
+  private String gameMode;
+  private List<MatchGameParticipantsDto> participants;
+}

--- a/src/main/java/com/nooblol/account/dto/match/MatchGameSimpleDto.java
+++ b/src/main/java/com/nooblol/account/dto/match/MatchGameSimpleDto.java
@@ -1,5 +1,6 @@
 package com.nooblol.account.dto.match;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import java.util.List;
 import lombok.Getter;
 import lombok.Setter;
@@ -7,9 +8,11 @@ import lombok.Setter;
 //간단한 전적 반환
 @Getter
 @Setter
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class MatchGameSimpleDto {
 
   private String puuid;
+  private String matchId;
 
   private String summonerId;
   private String summonerName;
@@ -43,5 +46,5 @@ public class MatchGameSimpleDto {
 
   private int queueId;
   private String gameMode;
-  private List<MatchGameParticipantsDto> participants;
+  private List<MatchGameSimpleDto> participants;
 }

--- a/src/main/java/com/nooblol/account/dto/match/MatchTeamDto.java
+++ b/src/main/java/com/nooblol/account/dto/match/MatchTeamDto.java
@@ -1,8 +1,0 @@
-package com.nooblol.account.dto.match;
-
-import lombok.NoArgsConstructor;
-
-@NoArgsConstructor
-public class MatchTeamDto {
-
-}

--- a/src/main/java/com/nooblol/account/mapper/MatchGameAddInfoMapper.java
+++ b/src/main/java/com/nooblol/account/mapper/MatchGameAddInfoMapper.java
@@ -1,0 +1,15 @@
+package com.nooblol.account.mapper;
+
+import com.nooblol.account.dto.match.MatchGameSimpleDto;
+import java.util.ArrayList;
+import java.util.Map;
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface MatchGameAddInfoMapper {
+
+  ArrayList<MatchGameSimpleDto> selectMatchSimpleList(Map<String, Object> searchParam);
+
+  ArrayList<MatchGameSimpleDto> selectMatchSimpleParticipantsList(String matchId);
+
+}

--- a/src/main/java/com/nooblol/account/mapper/MatchGameMapper.java
+++ b/src/main/java/com/nooblol/account/mapper/MatchGameMapper.java
@@ -1,8 +1,0 @@
-package com.nooblol.account.mapper;
-
-import org.apache.ibatis.annotations.Mapper;
-
-@Mapper
-public interface MatchGameMapper {
-
-}

--- a/src/main/java/com/nooblol/account/service/MatchGameInfoService.java
+++ b/src/main/java/com/nooblol/account/service/MatchGameInfoService.java
@@ -7,11 +7,12 @@ import java.util.List;
 
 public interface MatchGameInfoService {
 
-  ResponseDto getMatchInfoListByPuuid(String puuid, int pageNum) throws Exception;
+  ResponseDto getMatchInfoListByPuuid(String puuid, int pageNum, int limitNum) throws Exception;
 
-  List<MatchGameSimpleDto> selectMatchSimpleListByPuuidInDB(String puuid, int pageNum);
+  List<MatchGameSimpleDto> selectMatchSimpleListByPuuidInDB(String puuid, int pageNum,
+      int limitNum);
 
-  ResponseDto syncRiotToDbByPuuidAfterGetMatchSimpleList(String puuid, int pageNum)
+  ResponseDto syncRiotToDbByPuuidAfterGetMatchSimpleList(String puuid, int pageNum, int limitNum)
       throws Exception;
 
   ResponseDto syncRiotToDbDataProcess(String puuid) throws Exception;

--- a/src/main/java/com/nooblol/account/service/MatchGameInfoService.java
+++ b/src/main/java/com/nooblol/account/service/MatchGameInfoService.java
@@ -1,13 +1,18 @@
 package com.nooblol.account.service;
 
 import com.nooblol.account.dto.match.MatchDto;
+import com.nooblol.account.dto.match.MatchGameSimpleDto;
 import com.nooblol.global.dto.ResponseDto;
 import java.util.List;
-import org.springframework.transaction.annotation.Transactional;
 
 public interface MatchGameInfoService {
 
-  ResponseDto getMatchInfoListByPuuid(String puuid) throws Exception;
+  ResponseDto getMatchInfoListByPuuid(String puuid, int pageNum) throws Exception;
+
+  List<MatchGameSimpleDto> selectMatchSimpleListByPuuidInDB(String puuid, int pageNum);
+
+  ResponseDto syncRiotToDbByPuuidAfterGetMatchSimpleList(String puuid, int pageNum)
+      throws Exception;
 
   ResponseDto syncRiotToDbDataProcess(String puuid) throws Exception;
 

--- a/src/main/resources/mybatis/mapper/account/MatchGameAddInfoMapper.xml
+++ b/src/main/resources/mybatis/mapper/account/MatchGameAddInfoMapper.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+  "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.nooblol.account.mapper.MatchGameAddInfoMapper">
+  <select id="selectMatchSimpleList" parameterType="java.util.Map" resultType="MatchGameSimpleDto">
+    <if test="puuid != null and !puuid.equals('')">
+      SELECT
+      main.puuid, main.summoner_id, main.summoner_name, main.champion_id, main.champion_name,
+      main.role, main.lane, main.team_id,
+      main.team_position, main.kills, main.deaths, main.assists, main.summoner1_id,
+      main.summoner2_id, main.win,
+      main.item0, main.item1, main.item2, main.item3, main.item4, main.item5, main.item6,
+      info.match_id, info.game_creation, info.game_duration, info.queue_id, info.game_mode,
+      FROM
+      match_participants main,
+      match_gameinfo info
+      WHERE
+      main.match_id = info.match_id
+      AND main.puuid = #{puuid}
+      ORDER BY info.game_creation DESC
+      limit #{pageNum} , 30
+    </if>
+  </select>
+
+  <select id="selectMatchSimpleParticipantsList" parameterType="String"
+    resultType="MatchGameSimpleDto">
+    <if test="matchId != null and !matchId.equals('')">
+      SELECT puuid,summoner_id, match_id, summoner_name, champion_id, champion_name, team_id, win
+      FROM match_participants
+      WHERE match_id = #{match_id}
+      ORDER BY team_id
+    </if>
+  </select>
+</mapper>

--- a/src/main/resources/mybatis/mapper/account/MatchGameAddInfoMapper.xml
+++ b/src/main/resources/mybatis/mapper/account/MatchGameAddInfoMapper.xml
@@ -18,7 +18,7 @@
       main.match_id = info.match_id
       AND main.puuid = #{puuid}
       ORDER BY info.game_creation DESC
-      limit #{pageNum} , 30
+      limit #{pageNum} , #{limitNum}
     </if>
   </select>
 

--- a/src/main/resources/mybatis/mapper/account/MatchGameInfoMapper.xml
+++ b/src/main/resources/mybatis/mapper/account/MatchGameInfoMapper.xml
@@ -18,7 +18,6 @@
     </choose>
   </select>
 
-
   <!--아래의 Insert들은 모두 삽입하는 경우만 존재 함-->
   <insert id="insertMatchGameInfo" parameterType="MatchGameInfoDto">
     INSERT INTO MATCH_GAMEINFO(data_version, match_id, game_creation, game_duration,
@@ -44,14 +43,15 @@
   </insert>
 
   <insert id="insertMatchGameParticipants" parameterType="MatchGameInfoDto">
-    INSERT INTO MATCH_PARTICIPANTS(puuid, match_id, champion_name, champion_level, summoner_id,
-    summoner_name, kills, deaths, assists, role, lane, team_id, team_position, win,
+    INSERT INTO MATCH_PARTICIPANTS(puuid, match_id, champion_name, champion_level, champion_id,
+    summoner_id, summoner_name, kills, deaths, assists, role, lane, team_id, team_position, win,
     summoner1_casts, summoner1_id, summoner2_casts, summoner2_id, item0, item1, item2, item3, item4,
     item5, item6)
     VALUES
     <foreach collection="participants" item="item" separator=",">
-      (#{item.puuid}, #{matchId}, #{item.championName}, #{item.championLevel}, #{item.summonerId},
-      #{item.summonerName}, #{item.kills}, #{item.deaths}, #{item.assists}, #{item.role},
+      (#{item.puuid}, #{matchId}, #{item.championName}, #{item.championLevel}, #{item.championId},
+      #{item.summonerId}, #{item.summonerName}, #{item.kills}, #{item.deaths}, #{item.assists},
+      #{item.role},
       #{item.lane}, #{item.teamId}, #{item.teamPosition} , #{item.win},
       #{item.summoner1Casts}, #{item.summoner1Id}, #{item.summoner2Casts}, #{item.summoner2Id},
       #{item.item0}, #{item.item1}, #{item.item2}, #{item.item3}, #{item.item4}, #{item.item5},

--- a/src/main/resources/mybatis/mapper/account/MatchGameMapper.xml
+++ b/src/main/resources/mybatis/mapper/account/MatchGameMapper.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
-  "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="com.nooblol.account.mapper.MatchGameMapper">
-
-</mapper>

--- a/src/test/java/com/nooblol/account/service/impl/MatchGameInfoServiceImplTest.java
+++ b/src/test/java/com/nooblol/account/service/impl/MatchGameInfoServiceImplTest.java
@@ -75,7 +75,7 @@ class MatchGameInfoServiceImplTest {
   @DisplayName("getMatchInfoListByPuuid의 파라미터를 Null로 전달시 Exception이 발생한다")
   void confirm_getMatchInfoListByPuuid_IllegalArgumentExceptionTest() {
     Exception exception = assertThrows(IllegalArgumentException.class, () -> {
-      matchGameInfoService.getMatchInfoListByPuuid(null, 0);
+      matchGameInfoService.getMatchInfoListByPuuid(null, 0, 30);
     });
 
     assertEquals("PuuId가 입력되지 않았습니다.", exception.getMessage());
@@ -186,7 +186,7 @@ class MatchGameInfoServiceImplTest {
 
     ResponseDto resultResponse = null;
     try {
-      resultResponse = matchGameInfoService.getMatchInfoListByPuuid(responseNotFoundPuuid, 0);
+      resultResponse = matchGameInfoService.getMatchInfoListByPuuid(responseNotFoundPuuid, 0, 30);
     } catch (Exception e) {
       log.error(e.getMessage());
     }
@@ -215,7 +215,7 @@ class MatchGameInfoServiceImplTest {
         (ArrayList<MatchGameSimpleDto>) mockReturnList);
 
     List<MatchGameSimpleDto> returnList = (List<MatchGameSimpleDto>) matchGameInfoService.getMatchInfoListByPuuid(
-        responseOkPuuid, 0).getResult();
+        responseOkPuuid, 0, 30).getResult();
 
     assertEquals(returnList, mockReturnList);
   }

--- a/src/test/java/com/nooblol/account/service/impl/MatchGameInfoServiceImplTest.java
+++ b/src/test/java/com/nooblol/account/service/impl/MatchGameInfoServiceImplTest.java
@@ -1,7 +1,6 @@
 package com.nooblol.account.service.impl;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.when;
 
 
@@ -15,11 +14,14 @@ import com.nooblol.account.dto.match.RuneStatsDto;
 import com.nooblol.account.dto.match.RuneStyleDto;
 import com.nooblol.account.dto.match.RuneStyleSelectionDto;
 import com.nooblol.account.mapper.MatchGameInfoMapper;
+import com.nooblol.account.mapper.MatchGameAddInfoMapper;
 import com.nooblol.account.service.MatchGameListService;
 import com.nooblol.global.config.RiotConfiguration;
 import com.nooblol.global.dto.ResponseDto;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -37,6 +39,9 @@ class MatchGameInfoServiceImplTest {
 
   @Mock
   private MatchGameInfoMapper matchGameInfoMapper;
+
+  @Mock
+  private MatchGameAddInfoMapper matchGameAddInfoMapper;
 
   @Mock
   private RiotConfiguration riotConfiguration;
@@ -65,7 +70,7 @@ class MatchGameInfoServiceImplTest {
   @DisplayName("getMatchInfoListByPuuid의 파라미터 Null전달시 Exception테스트")
   void confirm_getMatchInfoListByPuuid_IllegalArgumentExceptionTest() {
     Exception exception = assertThrows(IllegalArgumentException.class, () -> {
-      matchGameInfoService.getMatchInfoListByPuuid(null, 1);
+      matchGameInfoService.getMatchInfoListByPuuid(null, 0);
     });
 
     assertEquals("PuuId가 입력되지 않았습니다.", exception.getMessage());
@@ -168,7 +173,7 @@ class MatchGameInfoServiceImplTest {
 
     ResponseDto resultResponse = null;
     try {
-      resultResponse = matchGameInfoService.getMatchInfoListByPuuid(responseNotFoundPuuid, 1);
+      resultResponse = matchGameInfoService.getMatchInfoListByPuuid(responseNotFoundPuuid, 0);
     } catch (Exception e) {
       e.printStackTrace();
     }
@@ -189,11 +194,15 @@ class MatchGameInfoServiceImplTest {
     mockReturnList.add(mockSample1);
     mockReturnList.add(mockSample2);
 
-    when(matchGameInfoMapper.selectMatchSimpleList(responseOkPuuid)).thenReturn(
+    Map<String, Object> searchParam = new HashMap<>();
+    searchParam.put("puuid", responseOkPuuid);
+    searchParam.put("pageNum", 0);
+
+    when(matchGameAddInfoMapper.selectMatchSimpleList(searchParam)).thenReturn(
         (ArrayList<MatchGameSimpleDto>) mockReturnList);
 
     List<MatchGameSimpleDto> returnList = (List<MatchGameSimpleDto>) matchGameInfoService.getMatchInfoListByPuuid(
-        responseOkPuuid, 1).getResult();
+        responseOkPuuid, 0).getResult();
 
     assertEquals(returnList, mockReturnList);
   }

--- a/src/test/java/com/nooblol/account/service/impl/MatchGameInfoServiceImplTest.java
+++ b/src/test/java/com/nooblol/account/service/impl/MatchGameInfoServiceImplTest.java
@@ -9,6 +9,7 @@ import com.nooblol.account.dto.match.MatchDto;
 import com.nooblol.account.dto.match.MatchGameInfoDto;
 import com.nooblol.account.dto.match.MatchGameParticipantsDto;
 import com.nooblol.account.dto.match.MatchGameRunesDto;
+import com.nooblol.account.dto.match.MatchGameSimpleDto;
 import com.nooblol.account.dto.match.MatchMetaDataDto;
 import com.nooblol.account.dto.match.RuneStatsDto;
 import com.nooblol.account.dto.match.RuneStyleDto;
@@ -64,7 +65,7 @@ class MatchGameInfoServiceImplTest {
   @DisplayName("getMatchInfoListByPuuid의 파라미터 Null전달시 Exception테스트")
   void confirm_getMatchInfoListByPuuid_IllegalArgumentExceptionTest() {
     Exception exception = assertThrows(IllegalArgumentException.class, () -> {
-      matchGameInfoService.getMatchInfoListByPuuid(null);
+      matchGameInfoService.getMatchInfoListByPuuid(null, 1);
     });
 
     assertEquals("PuuId가 입력되지 않았습니다.", exception.getMessage());
@@ -167,12 +168,34 @@ class MatchGameInfoServiceImplTest {
 
     ResponseDto resultResponse = null;
     try {
-      resultResponse = matchGameInfoService.getMatchInfoListByPuuid(responseNotFoundPuuid);
+      resultResponse = matchGameInfoService.getMatchInfoListByPuuid(responseNotFoundPuuid, 1);
     } catch (Exception e) {
       e.printStackTrace();
     }
 
     assertEquals(notFound.getResultCode(), resultResponse.getResultCode());
+  }
+
+  @Test
+  @DisplayName("DB에 게임 전적데이터가 존재하는 경우 List를 정상적으로 Return 받는지 여부 확인")
+  void getMatchSimpleListReturnByDBTest() throws Exception {
+    List<MatchGameSimpleDto> mockReturnList = new ArrayList<>();
+    MatchGameSimpleDto mockSample1 = new MatchGameSimpleDto();
+    mockSample1.setPuuid(responseOkPuuid);
+
+    MatchGameSimpleDto mockSample2 = new MatchGameSimpleDto();
+    mockSample2.setPuuid(responseOkPuuid);
+
+    mockReturnList.add(mockSample1);
+    mockReturnList.add(mockSample2);
+
+    when(matchGameInfoMapper.selectMatchSimpleList(responseOkPuuid)).thenReturn(
+        (ArrayList<MatchGameSimpleDto>) mockReturnList);
+
+    List<MatchGameSimpleDto> returnList = (List<MatchGameSimpleDto>) matchGameInfoService.getMatchInfoListByPuuid(
+        responseOkPuuid, 1).getResult();
+
+    assertEquals(returnList, mockReturnList);
   }
 
 }

--- a/src/test/java/com/nooblol/account/service/impl/MatchGameInfoServiceImplTest.java
+++ b/src/test/java/com/nooblol/account/service/impl/MatchGameInfoServiceImplTest.java
@@ -72,17 +72,6 @@ class MatchGameInfoServiceImplTest {
   }
 
   @Test
-  @DisplayName("getMatchInfoListByPuuid의 파라미터를 Null로 전달시 Exception이 발생한다")
-  void confirm_getMatchInfoListByPuuid_IllegalArgumentExceptionTest() {
-    Exception exception = assertThrows(IllegalArgumentException.class, () -> {
-      matchGameInfoService.getMatchInfoListByPuuid(null, 0, 30);
-    });
-
-    assertEquals("PuuId가 입력되지 않았습니다.", exception.getMessage());
-  }
-
-
-  @Test
   @DisplayName("insertMatchDataByDb메소드의 파라미터를 Null로 전달시 Return값이 false임을 확인한다")
   void confirm_InsertMatchDataByDB_ReturnFalseTest() {
     MatchDto dto = null;
@@ -210,6 +199,7 @@ class MatchGameInfoServiceImplTest {
     Map<String, Object> searchParam = new HashMap<>();
     searchParam.put("puuid", responseOkPuuid);
     searchParam.put("pageNum", 0);
+    searchParam.put("limitNum", 30);
 
     when(matchGameAddInfoMapper.selectMatchSimpleList(searchParam)).thenReturn(
         (ArrayList<MatchGameSimpleDto>) mockReturnList);

--- a/src/test/java/com/nooblol/account/service/impl/MatchGameInfoServiceImplTest.java
+++ b/src/test/java/com/nooblol/account/service/impl/MatchGameInfoServiceImplTest.java
@@ -179,7 +179,7 @@ class MatchGameInfoServiceImplTest {
   }
 
   @Test
-  @DisplayName("Riot 서버에 존재하지 않는 puuid를 발송하는 경우 NotFound를 반환 받는 테스트")
+  @DisplayName("Riot 서버에 존재하지 않는 puuid를 발송하는 경우 NotFound를 반환 받는다.")
   void getReturn_ResponseNotFound() {
     ResponseDto notFound = new ResponseDto(HttpStatus.NOT_FOUND.value(), HttpStatus.NOT_FOUND);
     when(matchGameListService.getMatchListId(responseNotFoundPuuid)).thenReturn(notFound);
@@ -195,7 +195,7 @@ class MatchGameInfoServiceImplTest {
   }
 
   @Test
-  @DisplayName("DB에 게임 전적데이터가 존재하는 경우 List를 정상적으로 Return 받는지 여부 확인")
+  @DisplayName("DB에 게임 전적데이터가 존재하는 상황에서 puuid 기대값으로 전적데이터가 List로 나온다")
   void getMatchSimpleListReturnByDBTest() throws Exception {
     List<MatchGameSimpleDto> mockReturnList = new ArrayList<>();
     MatchGameSimpleDto mockSample1 = new MatchGameSimpleDto();


### PR DESCRIPTION
소스 충돌이 있어서 PR이 지체되었습니당...

[#13 ]기능에 대한 구현입니다.
1. Controller에서 제공받은 puuid, sync, pagenum이라는 파라미터를 통해서 최근 전적데이터를 조회합니다.
2. Riot서버와 동기화하지않고 DB데이터를 바로 가져가려고 할 때는`데이터가 존재하는 경우` 에만 가능합니다.
3. 2번에서 데이터가 존재하지 않는 경우에는 `Riot과 동기화를 진행 후`  DB를 다시 조회하여 Return합니다.
4. Riot서버와 동기화 후 가져갈 경우에는 `동기화 진행 후` DB를 조회하여 결과를 Return합니다.
---
추가적으로 지난번에 남겨주신 validation기능과 fixture-monkey 기능은 회원관리부분을 구현하면서 해볼까합니다 :)

