### PR TITLE
매치데이터 누락된 추가사항 기능 정리 

### DIFF
--- a/src/main/java/com/nooblol/account/controller/MatchGameController.java
+++ b/src/main/java/com/nooblol/account/controller/MatchGameController.java
@@ -5,8 +5,7 @@ import com.nooblol.account.service.MatchGameInfoService;
 import com.nooblol.global.dto.ResponseDto;
 import javax.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -17,13 +16,12 @@ import org.springframework.web.bind.annotation.RestController;
  * 게임 매치정보에 대한 컨트롤러
  */
 
+@Slf4j
 @RestController
 @RequestMapping("/match")
 @RequiredArgsConstructor
 @Validated
 public class MatchGameController {
-
-  private final Logger log = LoggerFactory.getLogger(getClass());
 
   private final MatchGameInfoService matchGameInfoService;
   private final MatchGameAddInfoService matchGameAddInfoService;

--- a/src/main/java/com/nooblol/account/controller/MatchGameController.java
+++ b/src/main/java/com/nooblol/account/controller/MatchGameController.java
@@ -62,7 +62,9 @@ public class MatchGameController {
    * @return
    */
   @GetMapping("/participants")
-  public ResponseDto getMatchAllParticipants(@RequestParam("matchId") String matchId) {
+  public ResponseDto getMatchAllParticipants(
+      @RequestParam(value = "matchId", required = false) @NotBlank String matchId
+  ) {
     return matchGameAddInfoService.getMatchAllParticipantsList(matchId);
   }
 
@@ -73,7 +75,9 @@ public class MatchGameController {
    * @return
    */
   @GetMapping("/ban")
-  public ResponseDto getMatchBan(@RequestParam("matchId") String matchId) {
+  public ResponseDto getMatchBan(
+      @RequestParam(value = "matchId", required = false) @NotBlank String matchId
+  ) {
     return matchGameAddInfoService.getMatchBanList(matchId);
   }
 
@@ -86,10 +90,9 @@ public class MatchGameController {
    */
   @GetMapping("/rune")
   public ResponseDto getMatchUseRun(
-      @RequestParam("matchId") String matchId, @RequestParam("puuid") String puuid
+      @RequestParam(value = "matchId", required = false) @NotBlank String matchId,
+      @RequestParam(value = "puuid", required = false) @NotBlank String puuid
   ) {
     return matchGameAddInfoService.getMatchUseRunList(matchId, puuid);
   }
-
-
 }

--- a/src/main/java/com/nooblol/account/controller/MatchGameController.java
+++ b/src/main/java/com/nooblol/account/controller/MatchGameController.java
@@ -24,7 +24,7 @@ public class MatchGameController {
 
   private final MatchGameInfoService matchGameInfoService;
   private final MatchGameAddInfoService matchGameAddInfoService;
-
+  
   /**
    * 전적항목을 간단하게 표현함에 있어서 필요한 정보만 Return 한다. PUUID사용자의 가장최근 진행한 게임순으로 순차가 이뤄지며, 같이 참여한
    *
@@ -51,6 +51,11 @@ public class MatchGameController {
   @GetMapping("/participants")
   public ResponseDto getMatchAllParticipants(@RequestParam("matchId") String matchId) {
     return matchGameAddInfoService.getMatchAllParticipantsList(matchId);
+  }
+
+  @GetMapping("/ban")
+  public ResponseDto getMatchBan(@RequestParam("matchId") String matchId) {
+    return matchGameAddInfoService.getMatchBanList(matchId);
   }
 
 

--- a/src/main/java/com/nooblol/account/controller/MatchGameController.java
+++ b/src/main/java/com/nooblol/account/controller/MatchGameController.java
@@ -55,16 +55,35 @@ public class MatchGameController {
         limitNum);
   }
 
+  /**
+   * Match Id를 통하여 해당 게임에 참가한 모든 사용자에 대하여 DB에서 조회한다.
+   *
+   * @param matchId `/list` 에서 제공하는 항목중 MatchId값
+   * @return
+   */
   @GetMapping("/participants")
   public ResponseDto getMatchAllParticipants(@RequestParam("matchId") String matchId) {
     return matchGameAddInfoService.getMatchAllParticipantsList(matchId);
   }
 
+  /**
+   * Match Id를 통하여 해당 게임에서 금지된 챔피언의 목록을 조회한다.
+   *
+   * @param matchId `/list` 에서 제공하는 항목중 MatchId값
+   * @return
+   */
   @GetMapping("/ban")
   public ResponseDto getMatchBan(@RequestParam("matchId") String matchId) {
     return matchGameAddInfoService.getMatchBanList(matchId);
   }
 
+  /**
+   * MatchId와 Puuid를 통하여 해당 게임에서 특정유저(puuid)의 사용한 룬정보를 조회한다.
+   *
+   * @param matchId `/list` 에서 제공하는 항목중 MatchId값
+   * @param puuid   `/list`, `/participants` 에서 제공이된 사용자들의 puuid값
+   * @return
+   */
   @GetMapping("/rune")
   public ResponseDto getMatchUseRun(
       @RequestParam("matchId") String matchId, @RequestParam("puuid") String puuid

--- a/src/main/java/com/nooblol/account/controller/MatchGameController.java
+++ b/src/main/java/com/nooblol/account/controller/MatchGameController.java
@@ -24,7 +24,7 @@ public class MatchGameController {
 
   private final MatchGameInfoService matchGameInfoService;
   private final MatchGameAddInfoService matchGameAddInfoService;
-  
+
   /**
    * 전적항목을 간단하게 표현함에 있어서 필요한 정보만 Return 한다. PUUID사용자의 가장최근 진행한 게임순으로 순차가 이뤄지며, 같이 참여한
    *
@@ -56,6 +56,13 @@ public class MatchGameController {
   @GetMapping("/ban")
   public ResponseDto getMatchBan(@RequestParam("matchId") String matchId) {
     return matchGameAddInfoService.getMatchBanList(matchId);
+  }
+
+  @GetMapping("/rune")
+  public ResponseDto getMatchUseRun(
+      @RequestParam("matchId") String matchId, @RequestParam("puuid") String puuid
+  ) {
+    return matchGameAddInfoService.getMatchUseRunList(matchId, puuid);
   }
 
 

--- a/src/main/java/com/nooblol/account/controller/MatchGameController.java
+++ b/src/main/java/com/nooblol/account/controller/MatchGameController.java
@@ -3,9 +3,12 @@ package com.nooblol.account.controller;
 import com.nooblol.account.service.MatchGameAddInfoService;
 import com.nooblol.account.service.MatchGameInfoService;
 import com.nooblol.global.dto.ResponseDto;
+import com.nooblol.global.utils.ResponseEnum;
+import java.util.List;
 import javax.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -63,7 +66,7 @@ public class MatchGameController {
   public ResponseDto getMatchAllParticipants(
       @RequestParam(value = "matchId", required = false) @NotBlank String matchId
   ) {
-    return matchGameAddInfoService.getMatchAllParticipantsList(matchId);
+    return makeReturnValue(matchGameAddInfoService.getMatchAllParticipantsList(matchId));
   }
 
   /**
@@ -76,7 +79,7 @@ public class MatchGameController {
   public ResponseDto getMatchBan(
       @RequestParam(value = "matchId", required = false) @NotBlank String matchId
   ) {
-    return matchGameAddInfoService.getMatchBanList(matchId);
+    return makeReturnValue(matchGameAddInfoService.getMatchBanList(matchId));
   }
 
   /**
@@ -91,6 +94,24 @@ public class MatchGameController {
       @RequestParam(value = "matchId", required = false) @NotBlank String matchId,
       @RequestParam(value = "puuid", required = false) @NotBlank String puuid
   ) {
-    return matchGameAddInfoService.getMatchUseRunList(matchId, puuid);
+    return makeReturnValue(matchGameAddInfoService.getMatchUseRunList(matchId, puuid));
+  }
+
+  /**
+   * MatchGameInfo에서의 경우에는 사용하지 않은 방식이며, 해당 테이블의 경우 대량의 정보를 서로 주고받기 때문에 한개의 메소드에서 모든 처리를 하는 과정을 막고
+   * 싶었다.
+   * <p>
+   * 해당 클래스에서 사용한 이유는 MatchGameInfo에 비해 상대적으로 적은 요청이 들어오는 경우가 많을 것이라 예상되어 한개의 메소드에서 모든 Return작업을
+   * 처리하였다.
+   *
+   * @param list
+   * @param <T>
+   * @return
+   */
+  private <T> ResponseDto makeReturnValue(List<T> list) {
+    if (list == null || list.size() == 0) {
+      return ResponseEnum.NOT_FOUND.getResponse();
+    }
+    return new ResponseDto(HttpStatus.OK.value(), list);
   }
 }

--- a/src/main/java/com/nooblol/account/controller/MatchGameController.java
+++ b/src/main/java/com/nooblol/account/controller/MatchGameController.java
@@ -1,5 +1,6 @@
 package com.nooblol.account.controller;
 
+import com.nooblol.account.service.MatchGameAddInfoService;
 import com.nooblol.account.service.MatchGameInfoService;
 import com.nooblol.global.dto.ResponseDto;
 import lombok.RequiredArgsConstructor;
@@ -22,10 +23,11 @@ public class MatchGameController {
   private final Logger log = LoggerFactory.getLogger(getClass());
 
   private final MatchGameInfoService matchGameInfoService;
+  private final MatchGameAddInfoService matchGameAddInfoService;
 
   /**
-   * 전적항목을 간단하게 표현함에 있어서 필요한 정보만 Return 한다.
-   * PUUID사용자의 가장최근 진행한 게임순으로 순차가 이뤄지며, 같이 참여한
+   * 전적항목을 간단하게 표현함에 있어서 필요한 정보만 Return 한다. PUUID사용자의 가장최근 진행한 게임순으로 순차가 이뤄지며, 같이 참여한
+   *
    * @param puuid
    * @param sync
    * @param pageNum
@@ -33,7 +35,7 @@ public class MatchGameController {
    * @throws Exception
    */
   @GetMapping("/simplelist")
-  public ResponseDto selectMatchList(@RequestParam("puuid") String puuid,
+  public ResponseDto getMatchList(@RequestParam("puuid") String puuid,
       @RequestParam(value = "sync", required = false) boolean sync,
       @RequestParam(value = "page", defaultValue = "0") int pageNum) throws Exception {
     ResponseDto rtnData = null;
@@ -45,5 +47,11 @@ public class MatchGameController {
 
     return matchGameInfoService.syncRiotToDbByPuuidAfterGetMatchSimpleList(puuid, pageNum);
   }
+
+  @GetMapping("/participants")
+  public ResponseDto getMatchAllParticipants(@RequestParam("matchId") String matchId) {
+    return matchGameAddInfoService.getMatchAllParticipantsList(matchId);
+  }
+
 
 }

--- a/src/main/java/com/nooblol/account/controller/SummonerController.java
+++ b/src/main/java/com/nooblol/account/controller/SummonerController.java
@@ -4,19 +4,18 @@ import com.nooblol.account.service.SummonerHistoryService;
 import com.nooblol.account.service.SummonerService;
 import com.nooblol.global.dto.ResponseDto;
 import lombok.RequiredArgsConstructor;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+@Slf4j
 @RestController
 @RequestMapping("/summoner")
 @RequiredArgsConstructor
 public class SummonerController {
 
-  private final Logger log = LoggerFactory.getLogger(getClass());
 
   private final SummonerService summonerService;
   private final SummonerHistoryService summonerHistoryService;

--- a/src/main/java/com/nooblol/account/dto/match/MatchSearchDto.java
+++ b/src/main/java/com/nooblol/account/dto/match/MatchSearchDto.java
@@ -1,0 +1,19 @@
+package com.nooblol.account.dto.match;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class MatchSearchDto {
+
+  private String puuid;
+  private String matchId;
+  private int pageNum;
+  private int limitNum;
+
+}

--- a/src/main/java/com/nooblol/account/dto/match/MatchUseRuneDto.java
+++ b/src/main/java/com/nooblol/account/dto/match/MatchUseRuneDto.java
@@ -13,6 +13,6 @@ public class MatchUseRuneDto {
   private String puuid;
   private String matchId;
   private String type;
-  private String sortNo;
-  private String perk;
+  private int sortNo;
+  private int perk;
 }

--- a/src/main/java/com/nooblol/account/dto/match/MatchUseRuneDto.java
+++ b/src/main/java/com/nooblol/account/dto/match/MatchUseRuneDto.java
@@ -1,0 +1,18 @@
+package com.nooblol.account.dto.match;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class MatchUseRuneDto {
+
+  private String puuid;
+  private String matchId;
+  private String type;
+  private String sortNo;
+  private String perk;
+}

--- a/src/main/java/com/nooblol/account/mapper/MatchGameAddInfoMapper.java
+++ b/src/main/java/com/nooblol/account/mapper/MatchGameAddInfoMapper.java
@@ -1,5 +1,6 @@
 package com.nooblol.account.mapper;
 
+import com.nooblol.account.dto.match.MatchGameBansDto;
 import com.nooblol.account.dto.match.MatchGameParticipantsDto;
 import com.nooblol.account.dto.match.MatchGameSimpleDto;
 import java.util.ArrayList;
@@ -14,6 +15,8 @@ public interface MatchGameAddInfoMapper {
   ArrayList<MatchGameSimpleDto> selectMatchSimpleParticipantsList(String matchId);
 
   ArrayList<MatchGameParticipantsDto> selectMatchAllParticipantsListByMatchId(String matchId);
+
+  ArrayList<MatchGameBansDto> selectMatchGameBanList(String matchId);
 
 
 }

--- a/src/main/java/com/nooblol/account/mapper/MatchGameAddInfoMapper.java
+++ b/src/main/java/com/nooblol/account/mapper/MatchGameAddInfoMapper.java
@@ -1,5 +1,6 @@
 package com.nooblol.account.mapper;
 
+import com.nooblol.account.dto.match.MatchGameParticipantsDto;
 import com.nooblol.account.dto.match.MatchGameSimpleDto;
 import java.util.ArrayList;
 import java.util.Map;
@@ -11,5 +12,8 @@ public interface MatchGameAddInfoMapper {
   ArrayList<MatchGameSimpleDto> selectMatchSimpleList(Map<String, Object> searchParam);
 
   ArrayList<MatchGameSimpleDto> selectMatchSimpleParticipantsList(String matchId);
+
+  ArrayList<MatchGameParticipantsDto> selectMatchAllParticipantsListByMatchId(String matchId);
+
 
 }

--- a/src/main/java/com/nooblol/account/mapper/MatchGameAddInfoMapper.java
+++ b/src/main/java/com/nooblol/account/mapper/MatchGameAddInfoMapper.java
@@ -3,15 +3,17 @@ package com.nooblol.account.mapper;
 import com.nooblol.account.dto.match.MatchGameBansDto;
 import com.nooblol.account.dto.match.MatchGameParticipantsDto;
 import com.nooblol.account.dto.match.MatchGameSimpleDto;
+import com.nooblol.account.dto.match.MatchSearchDto;
 import com.nooblol.account.dto.match.MatchUseRuneDto;
 import java.util.ArrayList;
 import java.util.Map;
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
 
 @Mapper
 public interface MatchGameAddInfoMapper {
 
-  ArrayList<MatchGameSimpleDto> selectMatchSimpleList(Map<String, Object> searchParam);
+  ArrayList<MatchGameSimpleDto> selectMatchSimpleList(MatchSearchDto searchDto);
 
   ArrayList<MatchGameSimpleDto> selectMatchSimpleParticipantsList(String matchId);
 
@@ -19,6 +21,9 @@ public interface MatchGameAddInfoMapper {
 
   ArrayList<MatchGameBansDto> selectMatchGameBanList(String matchId);
 
-  ArrayList<MatchUseRuneDto> selectMatchGameUseRunes(Map<String, String> searchParam);
+  ArrayList<MatchUseRuneDto> selectMatchGameUseRunes(
+      @Param("puuid") String puuid,
+      @Param("matchId") String matchId
+  );
 
 }

--- a/src/main/java/com/nooblol/account/mapper/MatchGameAddInfoMapper.java
+++ b/src/main/java/com/nooblol/account/mapper/MatchGameAddInfoMapper.java
@@ -3,6 +3,7 @@ package com.nooblol.account.mapper;
 import com.nooblol.account.dto.match.MatchGameBansDto;
 import com.nooblol.account.dto.match.MatchGameParticipantsDto;
 import com.nooblol.account.dto.match.MatchGameSimpleDto;
+import com.nooblol.account.dto.match.MatchUseRuneDto;
 import java.util.ArrayList;
 import java.util.Map;
 import org.apache.ibatis.annotations.Mapper;
@@ -18,5 +19,6 @@ public interface MatchGameAddInfoMapper {
 
   ArrayList<MatchGameBansDto> selectMatchGameBanList(String matchId);
 
+  ArrayList<MatchUseRuneDto> selectMatchGameUseRunes(Map<String, String> searchParam);
 
 }

--- a/src/main/java/com/nooblol/account/service/MatchGameAddInfoService.java
+++ b/src/main/java/com/nooblol/account/service/MatchGameAddInfoService.java
@@ -1,5 +1,6 @@
 package com.nooblol.account.service;
 
+import com.nooblol.account.dto.match.MatchGameBansDto;
 import com.nooblol.account.dto.match.MatchGameParticipantsDto;
 import com.nooblol.global.dto.ResponseDto;
 import java.util.List;
@@ -9,5 +10,9 @@ public interface MatchGameAddInfoService {
   ResponseDto getMatchAllParticipantsList(String matchId);
 
   List<MatchGameParticipantsDto> selectMatchAllParticipantsListByMatchId(String matchId);
+
+  ResponseDto getMatchBanList(String matchId);
+
+  List<MatchGameBansDto> selectMatchBanListByMatchId(String matchId);
 
 }

--- a/src/main/java/com/nooblol/account/service/MatchGameAddInfoService.java
+++ b/src/main/java/com/nooblol/account/service/MatchGameAddInfoService.java
@@ -2,6 +2,7 @@ package com.nooblol.account.service;
 
 import com.nooblol.account.dto.match.MatchGameBansDto;
 import com.nooblol.account.dto.match.MatchGameParticipantsDto;
+import com.nooblol.account.dto.match.MatchUseRuneDto;
 import com.nooblol.global.dto.ResponseDto;
 import java.util.List;
 
@@ -15,4 +16,7 @@ public interface MatchGameAddInfoService {
 
   List<MatchGameBansDto> selectMatchBanListByMatchId(String matchId);
 
+  ResponseDto getMatchUseRunList(String matchId, String puuid);
+
+  List<MatchUseRuneDto> selectMatchUseRuneByMatchIdAndPuuid(String matchId, String puuid);
 }

--- a/src/main/java/com/nooblol/account/service/MatchGameAddInfoService.java
+++ b/src/main/java/com/nooblol/account/service/MatchGameAddInfoService.java
@@ -14,10 +14,7 @@ public interface MatchGameAddInfoService {
    * @param matchId
    * @return
    */
-  ResponseDto getMatchAllParticipantsList(String matchId);
-
-
-  List<MatchGameParticipantsDto> selectMatchAllParticipantsListByMatchId(String matchId);
+  List<MatchGameParticipantsDto> getMatchAllParticipantsList(String matchId);
 
   /**
    * 해당 Match Id 에서 벤이된 챔피언을 리스트로 전달하며, 어느팀에서 벤을 하였는지는 구분 되어있지 않다.
@@ -25,9 +22,7 @@ public interface MatchGameAddInfoService {
    * @param matchId
    * @return
    */
-  ResponseDto getMatchBanList(String matchId);
-
-  List<MatchGameBansDto> selectMatchBanListByMatchId(String matchId);
+  List<MatchGameBansDto> getMatchBanList(String matchId);
 
   /**
    * 사용자가 해당 경기에서 사용한 모든 룬정보 반환.
@@ -36,7 +31,6 @@ public interface MatchGameAddInfoService {
    * @param puuid
    * @return
    */
-  ResponseDto getMatchUseRunList(String matchId, String puuid);
+  List<MatchUseRuneDto> getMatchUseRunList(String matchId, String puuid);
 
-  List<MatchUseRuneDto> selectMatchUseRuneByMatchIdAndPuuid(String matchId, String puuid);
 }

--- a/src/main/java/com/nooblol/account/service/MatchGameAddInfoService.java
+++ b/src/main/java/com/nooblol/account/service/MatchGameAddInfoService.java
@@ -1,0 +1,13 @@
+package com.nooblol.account.service;
+
+import com.nooblol.account.dto.match.MatchGameParticipantsDto;
+import com.nooblol.global.dto.ResponseDto;
+import java.util.List;
+
+public interface MatchGameAddInfoService {
+
+  ResponseDto getMatchAllParticipantsList(String matchId);
+
+  List<MatchGameParticipantsDto> selectMatchAllParticipantsListByMatchId(String matchId);
+
+}

--- a/src/main/java/com/nooblol/account/service/MatchGameAddInfoService.java
+++ b/src/main/java/com/nooblol/account/service/MatchGameAddInfoService.java
@@ -8,14 +8,34 @@ import java.util.List;
 
 public interface MatchGameAddInfoService {
 
+  /**
+   * 해당 Match Id 에 참여한 모든 사용자의 게임 내용 반환
+   *
+   * @param matchId
+   * @return
+   */
   ResponseDto getMatchAllParticipantsList(String matchId);
+
 
   List<MatchGameParticipantsDto> selectMatchAllParticipantsListByMatchId(String matchId);
 
+  /**
+   * 해당 Match Id 에서 벤이된 챔피언을 리스트로 전달하며, 어느팀에서 벤을 하였는지는 구분 되어있지 않다.
+   *
+   * @param matchId
+   * @return
+   */
   ResponseDto getMatchBanList(String matchId);
 
   List<MatchGameBansDto> selectMatchBanListByMatchId(String matchId);
 
+  /**
+   * 사용자가 해당 경기에서 사용한 모든 룬정보 반환.
+   *
+   * @param matchId
+   * @param puuid
+   * @return
+   */
   ResponseDto getMatchUseRunList(String matchId, String puuid);
 
   List<MatchUseRuneDto> selectMatchUseRuneByMatchIdAndPuuid(String matchId, String puuid);

--- a/src/main/java/com/nooblol/account/service/MatchGameInfoService.java
+++ b/src/main/java/com/nooblol/account/service/MatchGameInfoService.java
@@ -5,13 +5,42 @@ import com.nooblol.account.dto.match.MatchGameSimpleDto;
 import com.nooblol.global.dto.ResponseDto;
 import java.util.List;
 
+/**
+ * 최근 50게임에 대한 정보만 동기화를 진행한다.
+ */
 public interface MatchGameInfoService {
 
+  /**
+   * DB의 게임 전적에 대하여 바로 Return 을 진행 하 , 데이터가 존재하지 않는 경우에는 동기화를 한 이후에 조회를 진행함)
+   *
+   * @param puuid    사용자 ID, Account의 Puuid.
+   * @param pageNum  불러올 페이지, 최초페이지 0부터 시작하며, DefaultValue는 0부터 시작한다.
+   * @param limitNum 한번 조회할때 불러올 갯수로 DefaultValuesms 30이다.
+   * @return
+   * @throws Exception
+   */
   ResponseDto getMatchInfoListByPuuid(String puuid, int pageNum, int limitNum) throws Exception;
 
+  /**
+   * 현재 DB에 있는 게임 매치 데이터를 반환한다.
+   *
+   * @param puuid    사용자 ID, Account의 Puuid.
+   * @param pageNum  불러올 페이지, 최초페이지 0부터 시작하며, DefaultValue는 0부터 시작한다.
+   * @param limitNum 한번 조회할때 불러올 갯수로 DefaultValuesms 30이다.
+   * @return
+   */
   List<MatchGameSimpleDto> selectMatchSimpleListByPuuidInDB(String puuid, int pageNum,
       int limitNum);
 
+  /**
+   * Riot서버에서 게임 매치 데이터를 받아와 DB에 Insert를 진행한다. 이후 DB에 Insert를 진행한 게임 매치 데이터를 조회하여 반환한다.
+   *
+   * @param puuid    사용자 ID, Account의 Puuid.
+   * @param pageNum  불러올 페이지, 최초페이지 0부터 시작하며, DefaultValue는 0부터 시작한다.
+   * @param limitNum 한번 조회할때 불러올 갯수로 DefaultValuesms 30이다.
+   * @return
+   * @throws Exception
+   */
   ResponseDto syncRiotToDbByPuuidAfterGetMatchSimpleList(String puuid, int pageNum, int limitNum)
       throws Exception;
 
@@ -23,7 +52,20 @@ public interface MatchGameInfoService {
 
   String getMakeUri(String matchId);
 
+  /**
+   * MatchId를 기반으로 Riot과 통신, 받아온 데이터를 MatchDto르 변환
+   *
+   * @param matchId
+   * @return
+   */
   MatchDto getMatchDataByRiot(String matchId);
 
+  /**
+   * 해당 트랜잭션은 모두 같이 처리되거나, 혹은 한개라도 실패할 경우 모두 Rollback이 되고 다음으로 Match를 Insert하는 것으로 넘어가게 된다.
+   *
+   * @param matchDto
+   * @return
+   * @throws Exception
+   */
   boolean insertMatchDataByDB(MatchDto matchDto) throws Exception;
 }

--- a/src/main/java/com/nooblol/account/service/MatchGameListService.java
+++ b/src/main/java/com/nooblol/account/service/MatchGameListService.java
@@ -4,12 +4,32 @@ import com.nooblol.global.dto.ResponseDto;
 
 /**
  * Account의 puuid를 통하여 MatchId의 List를 받아오는 Service
+ * https://developer.riotgames.com/apis#match-v5/GET_getMatchIdsByPUUID
+ * /lol/match/v5/matches/by-puuid/{puuid}/ids API사용
  */
 public interface MatchGameListService {
 
+  /**
+   * 최근 MatchId List를 가져온다
+   *
+   * @param puuid
+   * @return
+   */
   ResponseDto getMatchListId(String puuid);
 
+  /**
+   * 파라미터로 받은 Puuid를 기준으로 Riot서버와 통신을 하여 MatchId List를 반환한다. 통신결과가 없는 경우에는 NotFound를 Return한다.
+   *
+   * @param puuid
+   * @return
+   */
   ResponseDto getMatchListIdProcessByRiot(String puuid);
 
+  /**
+   * 파라미터로 받은 Puuid를 통해 MatchId리스트를 조회할 수 있도록 URI를 제작한다.
+   *
+   * @param puuid
+   * @return
+   */
   String getApiReplaceByPuuid(String puuid);
 }

--- a/src/main/java/com/nooblol/account/service/SummonerHistoryService.java
+++ b/src/main/java/com/nooblol/account/service/SummonerHistoryService.java
@@ -4,6 +4,13 @@ import com.nooblol.global.dto.ResponseDto;
 
 public interface SummonerHistoryService {
 
+  /**
+   * 소환사의 랭크정보를 Return한다.
+   *
+   * @param summonerId Account의 accoount_id값이다.
+   * @param sync       default값은 false이며, DB의 데이터를 조회할지, Riot서버의 정보를 조회후 Return할지 선택하는 Parameter다.
+   * @return
+   */
   ResponseDto getSummonerHistoryInfo(String summonerId, boolean sync);
 
 }

--- a/src/main/java/com/nooblol/account/service/SummonerService.java
+++ b/src/main/java/com/nooblol/account/service/SummonerService.java
@@ -8,8 +8,22 @@ public interface SummonerService {
 
   ResponseDto getSummonerAccointInfo(String summonerName);
 
+
+  /**
+   * 소환사명을 바탕으로 RiotAPI에 무조건 조회를 하며, 조회해온 데이터가 DB와 일치하는 경우 별다른 작업없이 반환하며 데이터가 변경이 있는 경우에는 DB Update
+   * 또는 Insert이후 RiotAPI에서 조회해온 데이터를 반환한다.
+   *
+   * @param summonerName 실제 사용하는 소환사명
+   * @return
+   */
   ResponseDto summonerAccountProcess(String summonerName);
 
+  /**
+   * 소환사명 검색 : https://kr.api.riotgames.com/lol/summoner/v4/summoners/by-name/
+   *
+   * @param summonerName
+   * @return
+   */
   ResponseDto selectSummonerAccountByRiot(String summonerName);
 
   void summonerAccountDBProcess(ResponseDto responseDto);

--- a/src/main/java/com/nooblol/account/service/impl/MatchGameAddInfoServiceImpl.java
+++ b/src/main/java/com/nooblol/account/service/impl/MatchGameAddInfoServiceImpl.java
@@ -6,11 +6,11 @@ import com.nooblol.account.dto.match.MatchUseRuneDto;
 import com.nooblol.account.mapper.MatchGameAddInfoMapper;
 import com.nooblol.account.service.MatchGameAddInfoService;
 import com.nooblol.global.dto.ResponseDto;
+import com.nooblol.global.utils.ResponseEnum;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
-import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
@@ -34,10 +34,6 @@ public class MatchGameAddInfoServiceImpl implements MatchGameAddInfoService {
   @Override
   @Transactional(readOnly = true)
   public ResponseDto getMatchAllParticipantsList(String matchId) {
-    if (StringUtils.isBlank(matchId)) {
-      throw new IllegalArgumentException(
-          "getMatchAllParticipantsList(String) : MatchId가 입력되지 않았습니다.");
-    }
     return makeReturnValue(selectMatchAllParticipantsListByMatchId(matchId));
   }
 
@@ -55,10 +51,6 @@ public class MatchGameAddInfoServiceImpl implements MatchGameAddInfoService {
   @Override
   @Transactional(readOnly = true)
   public ResponseDto getMatchBanList(String matchId) {
-    if (StringUtils.isBlank(matchId)) {
-      throw new IllegalArgumentException("getMatchBanList(String) : MatchId가 입력되지 않았습니다.");
-    }
-
     return makeReturnValue(selectMatchBanListByMatchId(matchId));
   }
 
@@ -78,12 +70,6 @@ public class MatchGameAddInfoServiceImpl implements MatchGameAddInfoService {
   @Override
   @Transactional(readOnly = true)
   public ResponseDto getMatchUseRunList(String matchId, String puuid) {
-    if (StringUtils.isBlank(matchId)) {
-      throw new IllegalArgumentException("getMatchUseRunList : MatchId가 입력되지 않았습니다.");
-    }
-    if (StringUtils.isBlank(puuid)) {
-      throw new IllegalArgumentException("getMatchUseRunList : puuid가 입력되지 않았습니다.");
-    }
     return makeReturnValue(selectMatchUseRuneByMatchIdAndPuuid(matchId, puuid));
   }
 
@@ -109,7 +95,7 @@ public class MatchGameAddInfoServiceImpl implements MatchGameAddInfoService {
    */
   private <T> ResponseDto makeReturnValue(List<T> list) {
     if (list == null || list.size() <= 0) {
-      return new ResponseDto(HttpStatus.NOT_FOUND.value(), HttpStatus.NOT_FOUND);
+      return ResponseEnum.NOT_FOUND.getResponse();
     }
     return new ResponseDto(HttpStatus.OK.value(), list);
   }

--- a/src/main/java/com/nooblol/account/service/impl/MatchGameAddInfoServiceImpl.java
+++ b/src/main/java/com/nooblol/account/service/impl/MatchGameAddInfoServiceImpl.java
@@ -1,5 +1,6 @@
 package com.nooblol.account.service.impl;
 
+import com.nooblol.account.dto.match.MatchGameBansDto;
 import com.nooblol.account.dto.match.MatchGameParticipantsDto;
 import com.nooblol.account.mapper.MatchGameAddInfoMapper;
 import com.nooblol.account.service.MatchGameAddInfoService;
@@ -40,6 +41,27 @@ public class MatchGameAddInfoServiceImpl implements MatchGameAddInfoService {
   @Transactional(readOnly = true)
   public List<MatchGameParticipantsDto> selectMatchAllParticipantsListByMatchId(String matchId) {
     return matchGameAddInfoMapper.selectMatchAllParticipantsListByMatchId(matchId);
+  }
+
+  /**
+   * 해당경기에서 벤이된 챔피언을 리스트로 전달하며, 어느팀에서 벤을 하였는지는 구분 되어있지 않다.
+   *
+   * @param matchId
+   * @return
+   */
+  @Override
+  public ResponseDto getMatchBanList(String matchId) {
+    if (StringUtils.isBlank(matchId)) {
+      throw new IllegalArgumentException("getMatchBanList(String) : MatchId가 입력되지 않았습니다.");
+    }
+
+    return makeReturnValue(matchGameAddInfoMapper.selectMatchGameBanList(matchId));
+  }
+
+  @Override
+  @Transactional(readOnly = true)
+  public List<MatchGameBansDto> selectMatchBanListByMatchId(String matchId) {
+    return matchGameAddInfoMapper.selectMatchGameBanList(matchId);
   }
 
 

--- a/src/main/java/com/nooblol/account/service/impl/MatchGameAddInfoServiceImpl.java
+++ b/src/main/java/com/nooblol/account/service/impl/MatchGameAddInfoServiceImpl.java
@@ -75,10 +75,7 @@ public class MatchGameAddInfoServiceImpl implements MatchGameAddInfoService {
 
   @Override
   public List<MatchUseRuneDto> selectMatchUseRuneByMatchIdAndPuuid(String matchId, String puuid) {
-    Map<String, String> paramMap = new HashMap<>();
-    paramMap.put("matchId", matchId);
-    paramMap.put("puuid", puuid);
-    return matchGameAddInfoMapper.selectMatchGameUseRunes(paramMap);
+    return matchGameAddInfoMapper.selectMatchGameUseRunes(puuid, matchId);
   }
 
 

--- a/src/main/java/com/nooblol/account/service/impl/MatchGameAddInfoServiceImpl.java
+++ b/src/main/java/com/nooblol/account/service/impl/MatchGameAddInfoServiceImpl.java
@@ -1,0 +1,63 @@
+package com.nooblol.account.service.impl;
+
+import com.nooblol.account.dto.match.MatchGameParticipantsDto;
+import com.nooblol.account.mapper.MatchGameAddInfoMapper;
+import com.nooblol.account.service.MatchGameAddInfoService;
+import com.nooblol.global.dto.ResponseDto;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class MatchGameAddInfoServiceImpl implements MatchGameAddInfoService {
+
+  private final Logger log = LoggerFactory.getLogger(getClass());
+
+  private final MatchGameAddInfoMapper matchGameAddInfoMapper;
+
+  /**
+   * 해당 경기에 참여한 모든 사용자의 게임 내용 반환
+   *
+   * @param matchId
+   * @return
+   */
+  @Override
+  public ResponseDto getMatchAllParticipantsList(String matchId) {
+    if (StringUtils.isBlank(matchId)) {
+      throw new IllegalArgumentException(
+          "getMatchAllParticipantsList(String) : MatchId가 입력되지 않았습니다.");
+    }
+    return makeReturnValue(selectMatchAllParticipantsListByMatchId(matchId));
+  }
+
+  @Override
+  @Transactional(readOnly = true)
+  public List<MatchGameParticipantsDto> selectMatchAllParticipantsListByMatchId(String matchId) {
+    return matchGameAddInfoMapper.selectMatchAllParticipantsListByMatchId(matchId);
+  }
+
+
+  /**
+   * MatchGameInfo에서의 경우에는 사용하지 않은 방식이며, 해당 테이블의 경우 대량의 정보를 서로 주고받기 때문에 한개의 메소드에서 모든 처리를 하는 과정을 막고
+   * 싶었다.
+   * <p>
+   * 해당 클래스에서 사용한 이유는 MatchGameInfo에 비해 상대적으로 적은 요청이 들어오는 경우가 많을 것이라 예상되어 한개의 메소드에서 모든 Return작업을
+   * 처리하였다.
+   *
+   * @param list
+   * @param <T>
+   * @return
+   */
+  private <T> ResponseDto makeReturnValue(List<T> list) {
+    if (list.size() > 0) {
+      return new ResponseDto(HttpStatus.OK.value(), list);
+    }
+    return new ResponseDto(HttpStatus.NOT_FOUND.value(), HttpStatus.NOT_FOUND);
+  }
+}

--- a/src/main/java/com/nooblol/account/service/impl/MatchGameAddInfoServiceImpl.java
+++ b/src/main/java/com/nooblol/account/service/impl/MatchGameAddInfoServiceImpl.java
@@ -2,10 +2,13 @@ package com.nooblol.account.service.impl;
 
 import com.nooblol.account.dto.match.MatchGameBansDto;
 import com.nooblol.account.dto.match.MatchGameParticipantsDto;
+import com.nooblol.account.dto.match.MatchUseRuneDto;
 import com.nooblol.account.mapper.MatchGameAddInfoMapper;
 import com.nooblol.account.service.MatchGameAddInfoService;
 import com.nooblol.global.dto.ResponseDto;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
@@ -62,6 +65,34 @@ public class MatchGameAddInfoServiceImpl implements MatchGameAddInfoService {
   @Transactional(readOnly = true)
   public List<MatchGameBansDto> selectMatchBanListByMatchId(String matchId) {
     return matchGameAddInfoMapper.selectMatchGameBanList(matchId);
+  }
+
+
+  /**
+   * 사용자가 해당 경기에서 사용한 모든 룬정보 반환.
+   *
+   * @param matchId
+   * @param puuid
+   * @return
+   */
+  @Override
+  public ResponseDto getMatchUseRunList(String matchId, String puuid) {
+    if (StringUtils.isBlank(matchId)) {
+      throw new IllegalArgumentException("getMatchUseRunList : MatchId가 입력되지 않았습니다.");
+    }
+    if (StringUtils.isBlank(puuid)) {
+      throw new IllegalArgumentException("getMatchUseRunList : puuid가 입력되지 않았습니다.");
+    }
+    return makeReturnValue(selectMatchUseRuneByMatchIdAndPuuid(matchId, puuid));
+  }
+
+  @Override
+  @Transactional(readOnly = true)
+  public List<MatchUseRuneDto> selectMatchUseRuneByMatchIdAndPuuid(String matchId, String puuid) {
+    Map<String, String> paramMap = new HashMap<>();
+    paramMap.put("matchId", matchId);
+    paramMap.put("puuid", puuid);
+    return matchGameAddInfoMapper.selectMatchGameUseRunes(paramMap);
   }
 
 

--- a/src/main/java/com/nooblol/account/service/impl/MatchGameAddInfoServiceImpl.java
+++ b/src/main/java/com/nooblol/account/service/impl/MatchGameAddInfoServiceImpl.java
@@ -9,17 +9,15 @@ import com.nooblol.global.dto.ResponseDto;
 import com.nooblol.global.utils.ResponseEnum;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
+@Slf4j
 @RequiredArgsConstructor
 public class MatchGameAddInfoServiceImpl implements MatchGameAddInfoService {
-
-  private final Logger log = LoggerFactory.getLogger(getClass());
 
   private final MatchGameAddInfoMapper matchGameAddInfoMapper;
 
@@ -71,7 +69,7 @@ public class MatchGameAddInfoServiceImpl implements MatchGameAddInfoService {
    * @return
    */
   private <T> ResponseDto makeReturnValue(List<T> list) {
-    if (list == null || list.size() <= 0) {
+    if (list == null || list.size() == 0) {
       return ResponseEnum.NOT_FOUND.getResponse();
     }
     return new ResponseDto(HttpStatus.OK.value(), list);

--- a/src/main/java/com/nooblol/account/service/impl/MatchGameAddInfoServiceImpl.java
+++ b/src/main/java/com/nooblol/account/service/impl/MatchGameAddInfoServiceImpl.java
@@ -5,12 +5,9 @@ import com.nooblol.account.dto.match.MatchGameParticipantsDto;
 import com.nooblol.account.dto.match.MatchUseRuneDto;
 import com.nooblol.account.mapper.MatchGameAddInfoMapper;
 import com.nooblol.account.service.MatchGameAddInfoService;
-import com.nooblol.global.dto.ResponseDto;
-import com.nooblol.global.utils.ResponseEnum;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -24,54 +21,21 @@ public class MatchGameAddInfoServiceImpl implements MatchGameAddInfoService {
 
   @Override
   @Transactional(readOnly = true)
-  public ResponseDto getMatchAllParticipantsList(String matchId) {
-    return makeReturnValue(selectMatchAllParticipantsListByMatchId(matchId));
-  }
-
-  @Override
-  @Transactional(readOnly = true)
-  public List<MatchGameParticipantsDto> selectMatchAllParticipantsListByMatchId(String matchId) {
+  public List<MatchGameParticipantsDto> getMatchAllParticipantsList(String matchId) {
     return matchGameAddInfoMapper.selectMatchAllParticipantsListByMatchId(matchId);
   }
 
   @Override
   @Transactional(readOnly = true)
-  public ResponseDto getMatchBanList(String matchId) {
-    return makeReturnValue(selectMatchBanListByMatchId(matchId));
-  }
-
-  @Override
-  public List<MatchGameBansDto> selectMatchBanListByMatchId(String matchId) {
+  public List<MatchGameBansDto> getMatchBanList(String matchId) {
     return matchGameAddInfoMapper.selectMatchGameBanList(matchId);
   }
 
   @Override
   @Transactional(readOnly = true)
-  public ResponseDto getMatchUseRunList(String matchId, String puuid) {
-    return makeReturnValue(selectMatchUseRuneByMatchIdAndPuuid(matchId, puuid));
-  }
-
-  @Override
-  public List<MatchUseRuneDto> selectMatchUseRuneByMatchIdAndPuuid(String matchId, String puuid) {
+  public List<MatchUseRuneDto> getMatchUseRunList(String matchId, String puuid) {
     return matchGameAddInfoMapper.selectMatchGameUseRunes(puuid, matchId);
   }
 
 
-  /**
-   * MatchGameInfo에서의 경우에는 사용하지 않은 방식이며, 해당 테이블의 경우 대량의 정보를 서로 주고받기 때문에 한개의 메소드에서 모든 처리를 하는 과정을 막고
-   * 싶었다.
-   * <p>
-   * 해당 클래스에서 사용한 이유는 MatchGameInfo에 비해 상대적으로 적은 요청이 들어오는 경우가 많을 것이라 예상되어 한개의 메소드에서 모든 Return작업을
-   * 처리하였다.
-   *
-   * @param list
-   * @param <T>
-   * @return
-   */
-  private <T> ResponseDto makeReturnValue(List<T> list) {
-    if (list == null || list.size() == 0) {
-      return ResponseEnum.NOT_FOUND.getResponse();
-    }
-    return new ResponseDto(HttpStatus.OK.value(), list);
-  }
 }

--- a/src/main/java/com/nooblol/account/service/impl/MatchGameAddInfoServiceImpl.java
+++ b/src/main/java/com/nooblol/account/service/impl/MatchGameAddInfoServiceImpl.java
@@ -7,9 +7,7 @@ import com.nooblol.account.mapper.MatchGameAddInfoMapper;
 import com.nooblol.account.service.MatchGameAddInfoService;
 import com.nooblol.global.dto.ResponseDto;
 import com.nooblol.global.utils.ResponseEnum;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -25,12 +23,7 @@ public class MatchGameAddInfoServiceImpl implements MatchGameAddInfoService {
 
   private final MatchGameAddInfoMapper matchGameAddInfoMapper;
 
-  /**
-   * 해당 경기에 참여한 모든 사용자의 게임 내용 반환
-   *
-   * @param matchId
-   * @return
-   */
+
   @Override
   @Transactional(readOnly = true)
   public ResponseDto getMatchAllParticipantsList(String matchId) {
@@ -38,16 +31,11 @@ public class MatchGameAddInfoServiceImpl implements MatchGameAddInfoService {
   }
 
   @Override
+  @Transactional(readOnly = true)
   public List<MatchGameParticipantsDto> selectMatchAllParticipantsListByMatchId(String matchId) {
     return matchGameAddInfoMapper.selectMatchAllParticipantsListByMatchId(matchId);
   }
 
-  /**
-   * 해당경기에서 벤이된 챔피언을 리스트로 전달하며, 어느팀에서 벤을 하였는지는 구분 되어있지 않다.
-   *
-   * @param matchId
-   * @return
-   */
   @Override
   @Transactional(readOnly = true)
   public ResponseDto getMatchBanList(String matchId) {
@@ -59,14 +47,6 @@ public class MatchGameAddInfoServiceImpl implements MatchGameAddInfoService {
     return matchGameAddInfoMapper.selectMatchGameBanList(matchId);
   }
 
-
-  /**
-   * 사용자가 해당 경기에서 사용한 모든 룬정보 반환.
-   *
-   * @param matchId
-   * @param puuid
-   * @return
-   */
   @Override
   @Transactional(readOnly = true)
   public ResponseDto getMatchUseRunList(String matchId, String puuid) {

--- a/src/main/java/com/nooblol/account/service/impl/MatchGameAddInfoServiceImpl.java
+++ b/src/main/java/com/nooblol/account/service/impl/MatchGameAddInfoServiceImpl.java
@@ -32,6 +32,7 @@ public class MatchGameAddInfoServiceImpl implements MatchGameAddInfoService {
    * @return
    */
   @Override
+  @Transactional(readOnly = true)
   public ResponseDto getMatchAllParticipantsList(String matchId) {
     if (StringUtils.isBlank(matchId)) {
       throw new IllegalArgumentException(
@@ -41,7 +42,6 @@ public class MatchGameAddInfoServiceImpl implements MatchGameAddInfoService {
   }
 
   @Override
-  @Transactional(readOnly = true)
   public List<MatchGameParticipantsDto> selectMatchAllParticipantsListByMatchId(String matchId) {
     return matchGameAddInfoMapper.selectMatchAllParticipantsListByMatchId(matchId);
   }
@@ -53,16 +53,16 @@ public class MatchGameAddInfoServiceImpl implements MatchGameAddInfoService {
    * @return
    */
   @Override
+  @Transactional(readOnly = true)
   public ResponseDto getMatchBanList(String matchId) {
     if (StringUtils.isBlank(matchId)) {
       throw new IllegalArgumentException("getMatchBanList(String) : MatchId가 입력되지 않았습니다.");
     }
 
-    return makeReturnValue(matchGameAddInfoMapper.selectMatchGameBanList(matchId));
+    return makeReturnValue(selectMatchBanListByMatchId(matchId));
   }
 
   @Override
-  @Transactional(readOnly = true)
   public List<MatchGameBansDto> selectMatchBanListByMatchId(String matchId) {
     return matchGameAddInfoMapper.selectMatchGameBanList(matchId);
   }
@@ -76,6 +76,7 @@ public class MatchGameAddInfoServiceImpl implements MatchGameAddInfoService {
    * @return
    */
   @Override
+  @Transactional(readOnly = true)
   public ResponseDto getMatchUseRunList(String matchId, String puuid) {
     if (StringUtils.isBlank(matchId)) {
       throw new IllegalArgumentException("getMatchUseRunList : MatchId가 입력되지 않았습니다.");
@@ -87,7 +88,6 @@ public class MatchGameAddInfoServiceImpl implements MatchGameAddInfoService {
   }
 
   @Override
-  @Transactional(readOnly = true)
   public List<MatchUseRuneDto> selectMatchUseRuneByMatchIdAndPuuid(String matchId, String puuid) {
     Map<String, String> paramMap = new HashMap<>();
     paramMap.put("matchId", matchId);

--- a/src/main/java/com/nooblol/account/service/impl/MatchGameAddInfoServiceImpl.java
+++ b/src/main/java/com/nooblol/account/service/impl/MatchGameAddInfoServiceImpl.java
@@ -108,9 +108,9 @@ public class MatchGameAddInfoServiceImpl implements MatchGameAddInfoService {
    * @return
    */
   private <T> ResponseDto makeReturnValue(List<T> list) {
-    if (list.size() > 0) {
-      return new ResponseDto(HttpStatus.OK.value(), list);
+    if (list == null || list.size() <= 0) {
+      return new ResponseDto(HttpStatus.NOT_FOUND.value(), HttpStatus.NOT_FOUND);
     }
-    return new ResponseDto(HttpStatus.NOT_FOUND.value(), HttpStatus.NOT_FOUND);
+    return new ResponseDto(HttpStatus.OK.value(), list);
   }
 }

--- a/src/main/java/com/nooblol/account/service/impl/MatchGameInfoServiceImpl.java
+++ b/src/main/java/com/nooblol/account/service/impl/MatchGameInfoServiceImpl.java
@@ -3,6 +3,7 @@ package com.nooblol.account.service.impl;
 import com.nooblol.account.dto.match.MatchDto;
 import com.nooblol.account.dto.match.MatchGameInfoDto;
 import com.nooblol.account.dto.match.MatchGameSimpleDto;
+import com.nooblol.account.dto.match.MatchSearchDto;
 import com.nooblol.account.dto.match.SyncResultDto;
 import com.nooblol.account.mapper.MatchGameInfoMapper;
 import com.nooblol.account.mapper.MatchGameAddInfoMapper;
@@ -76,13 +77,13 @@ public class MatchGameInfoServiceImpl implements MatchGameInfoService {
   @Transactional(readOnly = true)
   public List<MatchGameSimpleDto> selectMatchSimpleListByPuuidInDB(String puuid, int pageNum,
       int limitNum) {
-    Map<String, Object> searchParam = new HashMap<>();
-    searchParam.put("puuid", puuid);
-    searchParam.put("pageNum", pageNum);
-    searchParam.put("limitNum", limitNum);
+    MatchSearchDto searchDto = new MatchSearchDto();
+    searchDto.setPuuid(puuid);
+    searchDto.setPageNum(pageNum);
+    searchDto.setLimitNum(limitNum);
 
     List<MatchGameSimpleDto> selectMatchSimpleList =
-        matchGameAddInfoMapper.selectMatchSimpleList(searchParam);
+        matchGameAddInfoMapper.selectMatchSimpleList(searchDto);
 
     if (ObjectUtils.isEmpty(selectMatchSimpleList)) {
       return selectMatchSimpleList;
@@ -144,7 +145,7 @@ public class MatchGameInfoServiceImpl implements MatchGameInfoService {
     int totalSize = inputMatchList.size();
     int successCount = 0;
 
-    /**
+    /*
      * 한꺼번에 riot과 통신작업을 진행한 이후 받아온 데이터를 일괄적으로 Insert
      * inputMatchList를 Lambda로 사용하게 될 경우 익명 클래스에서 Exception을 처리하기 위해서 Try~Catch문을 사용해야 한다.
      * Try~Catch문을 사용하면서 Exception이 증발하여 Rollback이 되지않는 이슈가 존재하여 for문으로 수정.

--- a/src/main/java/com/nooblol/account/service/impl/MatchGameListServiceImpl.java
+++ b/src/main/java/com/nooblol/account/service/impl/MatchGameListServiceImpl.java
@@ -39,9 +39,6 @@ public class MatchGameListServiceImpl implements MatchGameListService {
 
   @Override
   public ResponseDto getMatchListId(String puuid) {
-    if (StringUtils.isBlank(puuid)) {
-      throw new IllegalArgumentException("PuuId가 입력되지 않았습니다.");
-    }
     return getMatchListIdProcessByRiot(puuid);
   }
 

--- a/src/main/java/com/nooblol/account/service/impl/MatchGameListServiceImpl.java
+++ b/src/main/java/com/nooblol/account/service/impl/MatchGameListServiceImpl.java
@@ -22,11 +22,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 
-/**
- * https://developer.riotgames.com/apis#match-v5/GET_getMatchIdsByPUUID
- * /lol/match/v5/matches/by-puuid/{puuid}/ids API사용
- */
-
 @Service
 @RequiredArgsConstructor
 public class MatchGameListServiceImpl implements MatchGameListService {
@@ -42,9 +37,6 @@ public class MatchGameListServiceImpl implements MatchGameListService {
     return getMatchListIdProcessByRiot(puuid);
   }
 
-  /**
-   * Riot에서 Puuid를 기반으로 MatchId List를 가져오는 총괄적인 역할을 한다 Riot과 통신이 실패하는 경우에는 무조건 Not_Found를 Return
-   */
   @Override
   public ResponseDto getMatchListIdProcessByRiot(String puuid) {
     String uri = getMakeUri(puuid);
@@ -56,34 +48,6 @@ public class MatchGameListServiceImpl implements MatchGameListService {
     }
 
     return new ResponseDto(HttpStatus.NOT_FOUND.value(), HttpStatus.NOT_FOUND);
-  }
-
-  private ResponseDto makeResponseToList(ResponseEntity response) {
-    HttpStatus sameStatus = HttpStatus.valueOf(response.getStatusCode().value());
-    if (sameStatus == HttpStatus.OK) {
-      return new ResponseDto(sameStatus.value(), getResponseBodyToList(response));
-    }
-    if (sameStatus != null) {
-      return new ResponseDto(sameStatus.value(), sameStatus);
-    }
-    return new ResponseDto(HttpStatus.NOT_FOUND.value(), HttpStatus.NOT_FOUND);
-  }
-
-  /**
-   * MatchId는 가장 최근 MatchId가 최상단에 오며, 순차적으로 가져와야 하여 ArrayList를 반환한다
-   *
-   * @param response
-   * @return
-   */
-  private ArrayList<String> getResponseBodyToList(ResponseEntity response) {
-    try {
-      String body = response.getBody().toString();
-      return objectMapper.readValue(body, new TypeReference<ArrayList<String>>() {
-      });
-    } catch (JsonProcessingException e) {
-      log.error("Json Parse Error : " + e.getMessage());
-      return null;
-    }
   }
 
   @Override
@@ -111,8 +75,8 @@ public class MatchGameListServiceImpl implements MatchGameListService {
       return uri.toString();
     } catch (URISyntaxException e) {
       log.error("URI Build Error : " + e.getMessage());
+      return null;
     }
-    return null;
   }
 
   private ResponseEntity responseResult(String uri) {
@@ -122,6 +86,34 @@ public class MatchGameListServiceImpl implements MatchGameListService {
       );
     } catch (Exception e) { //예외 상황이 발생한 경우 null을 Return하여 Not_Found를 타도록 함
       log.error("Riot Connect Error : " + e.getMessage());
+      return null;
+    }
+  }
+
+  private ResponseDto makeResponseToList(ResponseEntity response) {
+    HttpStatus sameStatus = HttpStatus.valueOf(response.getStatusCode().value());
+    if (sameStatus == HttpStatus.OK) {
+      return new ResponseDto(sameStatus.value(), getResponseBodyToList(response));
+    }
+    if (sameStatus != null) {
+      return new ResponseDto(sameStatus.value(), sameStatus);
+    }
+    return new ResponseDto(HttpStatus.NOT_FOUND.value(), HttpStatus.NOT_FOUND);
+  }
+
+  /**
+   * MatchId는 가장 최근 MatchId가 최상단에 오며, 순차적으로 가져와야 하여 ArrayList를 반환한다
+   *
+   * @param response
+   * @return
+   */
+  private ArrayList<String> getResponseBodyToList(ResponseEntity response) {
+    try {
+      String body = response.getBody().toString();
+      return objectMapper.readValue(body, new TypeReference<ArrayList<String>>() {
+      });
+    } catch (JsonProcessingException e) {
+      log.error("Json Parse Error : " + e.getMessage());
       return null;
     }
   }

--- a/src/main/java/com/nooblol/account/service/impl/SummonerHistoryServiceImpl.java
+++ b/src/main/java/com/nooblol/account/service/impl/SummonerHistoryServiceImpl.java
@@ -44,14 +44,6 @@ public class SummonerHistoryServiceImpl implements SummonerHistoryService {
     return summonerHistoryProcess(summonerId, sync);
   }
 
-  /**
-   * sync가 true인경우에만 DB의 값을 조회하며, 데이터가 존재하지 않거나 또는 false로 넘긴 경우 RiotAPI를 조회하여 정보를 취득한 이후 DB처리를 하고
-   * 반환한다.
-   *
-   * @param summonerId
-   * @param sync
-   * @return
-   */
   ResponseDto summonerHistoryProcess(String summonerId, boolean sync) {
     ResponseDto responseDto = null;
     if (sync) {

--- a/src/main/java/com/nooblol/account/service/impl/SummonerServiceImpl.java
+++ b/src/main/java/com/nooblol/account/service/impl/SummonerServiceImpl.java
@@ -43,13 +43,6 @@ public class SummonerServiceImpl implements SummonerService {
     return summonerAccountProcess(summonerName);
   }
 
-  /**
-   * 소환사명을 바탕으로 RiotAPI에 무조건 조회를 하며, 조회해온 데이터가 DB와 일치하는 경우 별다른 작업없이 반환하며 데이터가 변경이 있는 경우에는 DB Update
-   * 또는 Insert이후 RiotAPI에서 조회해온 데이터를 반환한다.
-   *
-   * @param summonerName
-   * @return
-   */
   @Override
   public ResponseDto summonerAccountProcess(String summonerName) {
     ResponseDto responseDto = selectSummonerAccountByRiot(summonerName);
@@ -74,12 +67,6 @@ public class SummonerServiceImpl implements SummonerService {
     }
   }
 
-  /**
-   * 소환사명 검색 : https://kr.api.riotgames.com/lol/summoner/v4/summoners/by-name/
-   *
-   * @param summonerName
-   * @return
-   */
   @Override
   public ResponseDto selectSummonerAccountByRiot(String summonerName) {
     summonerName = summonerNameWhiteSpaceReplace(summonerName);

--- a/src/main/java/com/nooblol/global/controller/RestApiControllerAdvice.java
+++ b/src/main/java/com/nooblol/global/controller/RestApiControllerAdvice.java
@@ -1,0 +1,33 @@
+package com.nooblol.global.controller;
+
+import com.nooblol.global.dto.ResponseDto;
+import com.nooblol.global.utils.ResponseEnum;
+import javax.validation.ConstraintViolationException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.util.ObjectUtils;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+/**
+ * Validation 을 진행하게 될 경우 ResponseEntity가 반환이 아닌, ResponseDto가 응답이 되도록 하기 위한 설정
+ */
+@RestControllerAdvice
+public class RestApiControllerAdvice {
+
+  private final Logger log = LoggerFactory.getLogger(getClass());
+
+  @ExceptionHandler({ConstraintViolationException.class, IllegalArgumentException.class})
+  public ResponseDto constraintViolationException(ConstraintViolationException e) {
+    if (!ObjectUtils.isEmpty(e)) {
+      e.getConstraintViolations().forEach(error -> {
+        log.error("[" + error.getRootBeanClass() + "] :"
+            + " ErrorTemplate : " + error.getMessageTemplate()
+            + ", PropertyPath : " + error.getPropertyPath()
+            + ", ErrorContent : " + error.getMessage()
+        );
+      });
+    }
+    return ResponseEnum.BAD_REQUEST.getResponse();
+  }
+}

--- a/src/main/java/com/nooblol/global/controller/RestApiControllerAdvice.java
+++ b/src/main/java/com/nooblol/global/controller/RestApiControllerAdvice.java
@@ -21,12 +21,13 @@ public class RestApiControllerAdvice {
   public ResponseDto constraintViolationException(ConstraintViolationException e) {
     if (!ObjectUtils.isEmpty(e)) {
       e.getConstraintViolations().forEach(error -> {
-        log.error("[" + error.getRootBeanClass() + "] :"
+        log.warn("[" + error.getRootBeanClass() + "] :"
             + " ErrorTemplate : " + error.getMessageTemplate()
             + ", PropertyPath : " + error.getPropertyPath()
             + ", ErrorContent : " + error.getMessage()
         );
       });
+      log.warn("Exception Trace : ", e);
     }
     return ResponseEnum.BAD_REQUEST.getResponse();
   }

--- a/src/main/java/com/nooblol/global/utils/ResponseEnum.java
+++ b/src/main/java/com/nooblol/global/utils/ResponseEnum.java
@@ -1,0 +1,27 @@
+package com.nooblol.global.utils;
+
+import com.nooblol.global.dto.ResponseDto;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+/**
+ * ResponseDto를 다들 공통된 리턴으로 하고자 제작. OK의 경우엔 setResponseResult로 추가적으로 Object를 삽입해줘야 한다.
+ */
+@Getter
+public enum ResponseEnum {
+  BAD_REQUEST(HttpStatus.BAD_REQUEST.value(), "잘못된 요청입니다. 파라미터를 확인 해주세요."),
+  NOT_FOUND(HttpStatus.NOT_FOUND.value(), HttpStatus.NOT_FOUND),
+  INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR.value(), "서버 에러"),
+  OK(HttpStatus.OK.value(), null);
+
+  ResponseDto response;
+
+  <T> ResponseEnum(int resultCode, T result) {
+    this.response = new ResponseDto(resultCode, result);
+  }
+
+  <T> void setResponseResult(T result) {
+    this.response.setResult(result);
+  }
+
+}

--- a/src/main/resources/mybatis/mapper/account/MatchGameAddInfoMapper.xml
+++ b/src/main/resources/mybatis/mapper/account/MatchGameAddInfoMapper.xml
@@ -39,4 +39,11 @@
     ORDER BY pick_turn
   </select>
 
+  <select id="selectMatchGameUseRunes" parameterType="java.util.Map" resultType="MatchUseRuneDto">
+    SELECT puuid, match_id, type, sort_no, perk
+    FROM match_game_runes
+    WHERE puuid = #{puuid}
+      AND MATCH_ID = #{matchId}
+    ORDER BY type, sort_no
+  </select>
 </mapper>

--- a/src/main/resources/mybatis/mapper/account/MatchGameAddInfoMapper.xml
+++ b/src/main/resources/mybatis/mapper/account/MatchGameAddInfoMapper.xml
@@ -32,4 +32,11 @@
   </select>
 
 
+  <select id="selectMatchGameBanList" parameterType="String" resultType="MatchGameBansDto">
+    SELECT champion_id, pick_turn
+    FROM match_game_bans
+    WHERE match_id = #{match_id}
+    ORDER BY pick_turn
+  </select>
+
 </mapper>

--- a/src/main/resources/mybatis/mapper/account/MatchGameAddInfoMapper.xml
+++ b/src/main/resources/mybatis/mapper/account/MatchGameAddInfoMapper.xml
@@ -2,32 +2,55 @@
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
   "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="com.nooblol.account.mapper.MatchGameAddInfoMapper">
-  <select id="selectMatchSimpleList" parameterType="java.util.Map" resultType="MatchGameSimpleDto">
-    <if test="puuid != null and !puuid.equals('')">
-      SELECT
-      main.puuid, main.summoner_id, main.summoner_name, main.champion_id, main.champion_name,
-      main.role, main.lane, main.team_id,
-      main.team_position, main.kills, main.deaths, main.assists, main.summoner1_id,
-      main.summoner2_id, main.win,
-      main.item0, main.item1, main.item2, main.item3, main.item4, main.item5, main.item6,
-      info.match_id, info.game_creation, info.game_duration, info.queue_id, info.game_mode,
-      FROM
-      match_participants main,
-      match_gameinfo info
-      WHERE
-      main.match_id = info.match_id
+  <select id="selectMatchSimpleList" parameterType="MatchSearchDto" resultType="MatchGameSimpleDto">
+    SELECT main.puuid,
+           main.summoner_id,
+           main.summoner_name,
+           main.champion_id,
+           main.champion_name,
+           main.role,
+           main.lane,
+           main.team_id,
+           main.team_position,
+           main.kills,
+           main.deaths,
+           main.assists,
+           main.summoner1_id,
+           main.summoner2_id,
+           main.win,
+           main.item0,
+           main.item1,
+           main.item2,
+           main.item3,
+           main.item4,
+           main.item5,
+           main.item6,
+           info.match_id,
+           info.game_creation,
+           info.game_duration,
+           info.queue_id,
+           info.game_mode,
+    FROM match_participants main,
+         match_gameinfo info
+    WHERE main.match_id = info.match_id
       AND main.puuid = #{puuid}
-      ORDER BY info.game_creation DESC
-      limit #{pageNum} , #{limitNum}
-    </if>
+    ORDER BY info.game_creation DESC
+      limit #{pageNum}, #{limitNum}
   </select>
 
   <select id="selectMatchSimpleParticipantsList" parameterType="String"
     resultType="MatchGameSimpleDto">
-    <if test="matchId != null and !matchId.equals('')">
-      SELECT puuid,summoner_id, match_id, summoner_name, champion_id, champion_name, team_id, win
-      FROM match_participants WHERE match_id = #{match_id} ORDER BY team_id
-    </if>
+    SELECT puuid,
+           summoner_id,
+           match_id,
+           summoner_name,
+           champion_id,
+           champion_name,
+           team_id,
+           win
+    FROM match_participants
+    WHERE match_id = #{match_id}
+    ORDER BY team_id
   </select>
 
   <select id="selectMatchAllParticipantsListByMatchId" parameterType="String"
@@ -46,7 +69,7 @@
     ORDER BY pick_turn
   </select>
 
-  <select id="selectMatchGameUseRunes" parameterType="java.util.Map" resultType="MatchUseRuneDto">
+  <select id="selectMatchGameUseRunes" parameterType="String" resultType="MatchUseRuneDto">
     SELECT puuid, match_id, type, sort_no, perk
     FROM match_game_runes
     WHERE puuid = #{puuid}

--- a/src/main/resources/mybatis/mapper/account/MatchGameAddInfoMapper.xml
+++ b/src/main/resources/mybatis/mapper/account/MatchGameAddInfoMapper.xml
@@ -6,19 +6,12 @@
     <if test="puuid != null and !puuid.equals('')">
       SELECT
       main.puuid, main.summoner_id, main.summoner_name, main.champion_id, main.champion_name,
-      main.role, main.lane, main.team_id,
-      main.team_position, main.kills, main.deaths, main.assists, main.summoner1_id,
-      main.summoner2_id, main.win,
-      main.item0, main.item1, main.item2, main.item3, main.item4, main.item5, main.item6,
-      info.match_id, info.game_creation, info.game_duration, info.queue_id, info.game_mode,
-      FROM
-      match_participants main,
-      match_gameinfo info
-      WHERE
-      main.match_id = info.match_id
-      AND main.puuid = #{puuid}
-      ORDER BY info.game_creation DESC
-      limit #{pageNum} , 30
+      main.role, main.lane, main.team_id, main.team_position, main.kills, main.deaths, main.assists,
+      main.summoner1_id, main.summoner2_id, main.win, main.item0, main.item1, main.item2,
+      main.item3, main.item4, main.item5, main.item6, info.match_id, info.game_creation,
+      info.game_duration, info.queue_id, info.game_mode, FROM match_participants main,
+      match_gameinfo info WHERE main.match_id = info.match_id AND main.puuid = #{puuid} ORDER BY
+      info.game_creation DESC limit #{pageNum} , 30
     </if>
   </select>
 
@@ -26,9 +19,17 @@
     resultType="MatchGameSimpleDto">
     <if test="matchId != null and !matchId.equals('')">
       SELECT puuid,summoner_id, match_id, summoner_name, champion_id, champion_name, team_id, win
-      FROM match_participants
-      WHERE match_id = #{match_id}
-      ORDER BY team_id
+      FROM match_participants WHERE match_id = #{match_id} ORDER BY team_id
     </if>
   </select>
+
+  <select id="selectMatchAllParticipantsListByMatchId" parameterType="String"
+    resultType="MatchGameParticipantsDto">
+    SELECT *
+    FROM match_participants
+    WHERE match_id = #{match_id}
+    ORDER BY team_id
+  </select>
+
+
 </mapper>

--- a/src/main/resources/mybatis/mapper/account/MatchGameInfoMapper.xml
+++ b/src/main/resources/mybatis/mapper/account/MatchGameInfoMapper.xml
@@ -3,16 +3,15 @@
   "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="com.nooblol.account.mapper.MatchGameInfoMapper">
   <select id="existsMatchIdListByMatch" parameterType="String" resultType="arrayList">
-    <if test="matchIdList != null and !matchIdList.equals('')">
-      select match_id
-      from match_gameinfo main
-      where exists(
-      select 1 from match_gameinfo sub
-      where main.match_id = sub.match_id
-      and match_id in
-      (#{matchIdList})
-      )
-    </if>
+    select match_id
+    from match_gameinfo main
+    where exists(
+            select 1
+            from match_gameinfo sub
+            where main.match_id = sub.match_id
+              and match_id in
+                  (#{matchIdList})
+            )
   </select>
 
   <!--아래의 Insert들은 모두 삽입하는 경우만 존재 함-->

--- a/src/test/java/com/nooblol/account/service/impl/MatchGameAddInfoServiceImplTest.java
+++ b/src/test/java/com/nooblol/account/service/impl/MatchGameAddInfoServiceImplTest.java
@@ -31,20 +31,7 @@ class MatchGameAddInfoServiceImplTest {
     matchGameAddInfoMapper = Mockito.mock(MatchGameAddInfoMapper.class);
     this.matchGameAddInfoService = new MatchGameAddInfoServiceImpl(matchGameAddInfoMapper);
   }
-
-
-  @Test
-  @DisplayName("모든 참가자 정보 조회시 MatchId를 Null로 조회할 경우 Exception을 획득 한다.")
-  void matchAllParticipantsList_ExceptionTest() {
-    Exception exception = assertThrows(IllegalArgumentException.class, () -> {
-      String matchId = null;
-      matchGameAddInfoService.getMatchAllParticipantsList(matchId);
-    });
-
-    assertEquals("getMatchAllParticipantsList(String) : MatchId가 입력되지 않았습니다.",
-        exception.getMessage());
-  }
-
+  
   @Test
   @DisplayName("모든 참가자 정보 조회시 DB에 존재하는 MatchId인 경우 OK상태값을 획득 한다.")
   void matchAllParticipantsList_ListReturnOkTest() {
@@ -90,18 +77,6 @@ class MatchGameAddInfoServiceImplTest {
     assertThat(result.getResultCode()).isEqualTo(HttpStatus.NOT_FOUND.value());
   }
 
-
-  @Test
-  @DisplayName("게임의 벤이된 챔피언리스트 조회시 MatchId를 Null로 조회할 경우 Exception을 획득 한다.")
-  void matchBanList_ExceptionTest() {
-    Exception exception = assertThrows(IllegalArgumentException.class, () -> {
-      String matchId = null;
-      matchGameAddInfoService.getMatchBanList(matchId);
-    });
-
-    assertEquals("getMatchBanList(String) : MatchId가 입력되지 않았습니다.", exception.getMessage());
-  }
-
   @Test
   @DisplayName("게임의 벤이된 챔피언리스트 조회시 DB에 존재하는 MatchId인 경우 OK상태값을 획득 한다.")
   void matchBanList_ListReturnOkTest() {
@@ -145,43 +120,6 @@ class MatchGameAddInfoServiceImplTest {
 
     ResponseDto result = matchGameAddInfoService.getMatchBanList(matchId);
     assertThat(result.getResultCode()).isEqualTo(HttpStatus.NOT_FOUND.value());
-  }
-
-
-  @Test
-  @DisplayName("게임에서 사용한 특정 유저의 룬정보 조회시 MatchId가 Null로 조회할 경우 Exception을 획득 한다.")
-  void getMatchUseRuneList_MatchIdNullExceptionTest() {
-    Exception exception = assertThrows(IllegalArgumentException.class, () -> {
-      String matchId = null;
-      String puuid = "a";
-      matchGameAddInfoService.getMatchUseRunList(matchId, puuid);
-    });
-
-    assertEquals("getMatchUseRunList : MatchId가 입력되지 않았습니다.", exception.getMessage());
-  }
-
-  @Test
-  @DisplayName("게임에서 사용한 특정 유저의 룬정보 조회시 MatchId와 Puuid를 Null로 조회할 경우 MatchId Exception을 획득 한다.")
-  void getMatchUseRuneList_MatchIdNullExceptionTest2() {
-    Exception exception = assertThrows(IllegalArgumentException.class, () -> {
-      String matchId = null;
-      String puuid = null;
-      matchGameAddInfoService.getMatchUseRunList(matchId, puuid);
-    });
-
-    assertEquals("getMatchUseRunList : MatchId가 입력되지 않았습니다.", exception.getMessage());
-  }
-
-  @Test
-  @DisplayName("게임에서 사용한 특정 유저의 룬정보 조회시 Puuid가 Null로 조회할 경우 Puuid의 Exception을 획득 한다.")
-  void getMatchUseRuneList_PuuIdNullExceptionTest() {
-    Exception exception = assertThrows(IllegalArgumentException.class, () -> {
-      String matchId = "sample";
-      String puuid = null;
-      matchGameAddInfoService.getMatchUseRunList(matchId, puuid);
-    });
-
-    assertEquals("getMatchUseRunList : puuid가 입력되지 않았습니다.", exception.getMessage());
   }
 
   @Test

--- a/src/test/java/com/nooblol/account/service/impl/MatchGameAddInfoServiceImplTest.java
+++ b/src/test/java/com/nooblol/account/service/impl/MatchGameAddInfoServiceImplTest.java
@@ -11,9 +11,7 @@ import com.nooblol.account.mapper.MatchGameAddInfoMapper;
 import com.nooblol.account.service.MatchGameAddInfoService;
 import com.nooblol.global.dto.ResponseDto;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
@@ -31,7 +29,7 @@ class MatchGameAddInfoServiceImplTest {
     matchGameAddInfoMapper = Mockito.mock(MatchGameAddInfoMapper.class);
     this.matchGameAddInfoService = new MatchGameAddInfoServiceImpl(matchGameAddInfoMapper);
   }
-  
+
   @Test
   @DisplayName("모든 참가자 정보 조회시 DB에 존재하는 MatchId인 경우 OK상태값을 획득 한다.")
   void matchAllParticipantsList_ListReturnOkTest() {
@@ -147,10 +145,7 @@ class MatchGameAddInfoServiceImplTest {
     mockReturnList.add(rune4);
     mockReturnList.add(rune5);
 
-    Map<String, String> paramMap = new HashMap<>();
-    paramMap.put("matchId", matchId);
-    paramMap.put("puuid", puuid);
-    given(matchGameAddInfoMapper.selectMatchGameUseRunes(paramMap))
+    given(matchGameAddInfoMapper.selectMatchGameUseRunes(puuid, matchId))
         .willReturn(mockReturnList);
 
     ResponseDto result = matchGameAddInfoService.getMatchUseRunList(matchId, puuid);

--- a/src/test/java/com/nooblol/account/service/impl/MatchGameAddInfoServiceImplTest.java
+++ b/src/test/java/com/nooblol/account/service/impl/MatchGameAddInfoServiceImplTest.java
@@ -1,0 +1,236 @@
+package com.nooblol.account.service.impl;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import com.nooblol.account.dto.match.MatchGameBansDto;
+import com.nooblol.account.dto.match.MatchGameParticipantsDto;
+import com.nooblol.account.dto.match.MatchUseRuneDto;
+import com.nooblol.account.mapper.MatchGameAddInfoMapper;
+import com.nooblol.account.service.MatchGameAddInfoService;
+import com.nooblol.global.dto.ResponseDto;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.springframework.http.HttpStatus;
+
+class MatchGameAddInfoServiceImplTest {
+
+  @Mock
+  private MatchGameAddInfoMapper matchGameAddInfoMapper;
+
+  private MatchGameAddInfoService matchGameAddInfoService;
+
+  public MatchGameAddInfoServiceImplTest() {
+    matchGameAddInfoMapper = Mockito.mock(MatchGameAddInfoMapper.class);
+    this.matchGameAddInfoService = new MatchGameAddInfoServiceImpl(matchGameAddInfoMapper);
+  }
+
+
+  @Test
+  @DisplayName("모든 참가자 정보 조회시 MatchId를 Null로 조회할 경우 Exception을 획득 한다.")
+  void matchAllParticipantsList_ExceptionTest() {
+    Exception exception = assertThrows(IllegalArgumentException.class, () -> {
+      String matchId = null;
+      matchGameAddInfoService.getMatchAllParticipantsList(matchId);
+    });
+
+    assertEquals("getMatchAllParticipantsList(String) : MatchId가 입력되지 않았습니다.",
+        exception.getMessage());
+  }
+
+  @Test
+  @DisplayName("모든 참가자 정보 조회시 DB에 존재하는 MatchId인 경우 OK상태값을 획득 한다.")
+  void matchAllParticipantsList_ListReturnOkTest() {
+    ArrayList<MatchGameParticipantsDto> mockReturnList = new ArrayList<>();
+    String matchId = "KR_6064599598";
+
+    MatchGameParticipantsDto part1 = new MatchGameParticipantsDto();
+    part1.setSummonerName("샢믈1");
+    MatchGameParticipantsDto part2 = new MatchGameParticipantsDto();
+    part2.setSummonerName("샢믈2");
+    MatchGameParticipantsDto part3 = new MatchGameParticipantsDto();
+    part3.setSummonerName("샢믈3");
+    MatchGameParticipantsDto part4 = new MatchGameParticipantsDto();
+    part4.setSummonerName("샢믈4");
+    MatchGameParticipantsDto part5 = new MatchGameParticipantsDto();
+    part5.setSummonerName("샢믈5");
+
+    mockReturnList.add(part1);
+    mockReturnList.add(part2);
+    mockReturnList.add(part3);
+    mockReturnList.add(part4);
+    mockReturnList.add(part5);
+
+    when(matchGameAddInfoMapper.selectMatchAllParticipantsListByMatchId(matchId))
+        .thenReturn(mockReturnList);
+
+    ResponseDto result = matchGameAddInfoService.getMatchAllParticipantsList(matchId);
+    List<MatchGameParticipantsDto> resultList = (List<MatchGameParticipantsDto>) result.getResult();
+    assertThat(result.getResultCode()).isEqualTo(HttpStatus.OK.value());
+    assertThat(resultList.size() > 0).isTrue();
+  }
+
+  @Test
+  @DisplayName("모든 참가자 정보 조회시 DB에 존재하지 않는 MatchId인 경우 NotFound를 획득 한다.")
+  void matchAllParticipantsList_ReturnNotFound() {
+    ArrayList<MatchGameParticipantsDto> mockReturnList = new ArrayList<>();
+    String matchId = "KR_6064599598";
+
+    given(matchGameAddInfoMapper.selectMatchAllParticipantsListByMatchId(matchId))
+        .willReturn(mockReturnList);
+
+    ResponseDto result = matchGameAddInfoService.getMatchAllParticipantsList(matchId);
+    assertThat(result.getResultCode()).isEqualTo(HttpStatus.NOT_FOUND.value());
+  }
+
+
+  @Test
+  @DisplayName("게임의 벤이된 챔피언리스트 조회시 MatchId를 Null로 조회할 경우 Exception을 획득 한다.")
+  void matchBanList_ExceptionTest() {
+    Exception exception = assertThrows(IllegalArgumentException.class, () -> {
+      String matchId = null;
+      matchGameAddInfoService.getMatchBanList(matchId);
+    });
+
+    assertEquals("getMatchBanList(String) : MatchId가 입력되지 않았습니다.", exception.getMessage());
+  }
+
+  @Test
+  @DisplayName("게임의 벤이된 챔피언리스트 조회시 DB에 존재하는 MatchId인 경우 OK상태값을 획득 한다.")
+  void matchBanList_ListReturnOkTest() {
+    ArrayList<MatchGameBansDto> mockReturnList = new ArrayList<>();
+    String matchId = "KR_6064599598";
+
+    MatchGameBansDto ban1 = new MatchGameBansDto();
+    ban1.setChampionId(22);
+    MatchGameBansDto ban2 = new MatchGameBansDto();
+    ban2.setChampionId(23);
+    MatchGameBansDto ban3 = new MatchGameBansDto();
+    ban3.setChampionId(24);
+    MatchGameBansDto ban4 = new MatchGameBansDto();
+    ban4.setChampionId(25);
+    MatchGameBansDto ban5 = new MatchGameBansDto();
+    ban5.setChampionId(26);
+
+    mockReturnList.add(ban1);
+    mockReturnList.add(ban2);
+    mockReturnList.add(ban3);
+    mockReturnList.add(ban4);
+    mockReturnList.add(ban5);
+
+    given(matchGameAddInfoMapper.selectMatchGameBanList(matchId))
+        .willReturn(mockReturnList);
+
+    ResponseDto result = matchGameAddInfoService.getMatchBanList(matchId);
+    List<MatchGameBansDto> resultList = (List<MatchGameBansDto>) result.getResult();
+    assertThat(result.getResultCode()).isEqualTo(HttpStatus.OK.value());
+    assertThat(resultList.size() > 0).isTrue();
+  }
+
+  @Test
+  @DisplayName("게임의 벤이된 챔피언리스트 조회시 DB에 존재하지 않는 MatchId인 경우 NotFound를 획득 한다.")
+  void matchBanList_ReturnNotFound() {
+    ArrayList<MatchGameBansDto> mockReturnList = new ArrayList<>();
+    String matchId = "KR_6064599598";
+
+    given(matchGameAddInfoMapper.selectMatchGameBanList(matchId))
+        .willReturn(mockReturnList);
+
+    ResponseDto result = matchGameAddInfoService.getMatchBanList(matchId);
+    assertThat(result.getResultCode()).isEqualTo(HttpStatus.NOT_FOUND.value());
+  }
+
+
+  @Test
+  @DisplayName("게임에서 사용한 특정 유저의 룬정보 조회시 MatchId가 Null로 조회할 경우 Exception을 획득 한다.")
+  void getMatchUseRuneList_MatchIdNullExceptionTest() {
+    Exception exception = assertThrows(IllegalArgumentException.class, () -> {
+      String matchId = null;
+      String puuid = "a";
+      matchGameAddInfoService.getMatchUseRunList(matchId, puuid);
+    });
+
+    assertEquals("getMatchUseRunList : MatchId가 입력되지 않았습니다.", exception.getMessage());
+  }
+
+  @Test
+  @DisplayName("게임에서 사용한 특정 유저의 룬정보 조회시 MatchId와 Puuid를 Null로 조회할 경우 MatchId Exception을 획득 한다.")
+  void getMatchUseRuneList_MatchIdNullExceptionTest2() {
+    Exception exception = assertThrows(IllegalArgumentException.class, () -> {
+      String matchId = null;
+      String puuid = null;
+      matchGameAddInfoService.getMatchUseRunList(matchId, puuid);
+    });
+
+    assertEquals("getMatchUseRunList : MatchId가 입력되지 않았습니다.", exception.getMessage());
+  }
+
+  @Test
+  @DisplayName("게임에서 사용한 특정 유저의 룬정보 조회시 Puuid가 Null로 조회할 경우 Puuid의 Exception을 획득 한다.")
+  void getMatchUseRuneList_PuuIdNullExceptionTest() {
+    Exception exception = assertThrows(IllegalArgumentException.class, () -> {
+      String matchId = "sample";
+      String puuid = null;
+      matchGameAddInfoService.getMatchUseRunList(matchId, puuid);
+    });
+
+    assertEquals("getMatchUseRunList : puuid가 입력되지 않았습니다.", exception.getMessage());
+  }
+
+  @Test
+  @DisplayName("게임에서 사용한 특정 유저의 룬정보 조회시 DB에 존재하는 MatchId, Puuid인 경우 OK상태값을 획득 한다.")
+  void getMatchUseRuneList_ListReturnOkTest() {
+    ArrayList<MatchUseRuneDto> mockReturnList = new ArrayList<>();
+    String matchId = "KR_6064599598";
+    String puuid = "Test_Puuid";
+
+    MatchUseRuneDto rune1 = new MatchUseRuneDto();
+    MatchUseRuneDto rune2 = new MatchUseRuneDto();
+    MatchUseRuneDto rune3 = new MatchUseRuneDto();
+    MatchUseRuneDto rune4 = new MatchUseRuneDto();
+    MatchUseRuneDto rune5 = new MatchUseRuneDto();
+
+    rune1.setMatchId(matchId);
+    rune2.setMatchId(matchId);
+    rune3.setMatchId(matchId);
+    rune4.setMatchId(matchId);
+    rune5.setMatchId(matchId);
+
+    mockReturnList.add(rune1);
+    mockReturnList.add(rune2);
+    mockReturnList.add(rune3);
+    mockReturnList.add(rune4);
+    mockReturnList.add(rune5);
+
+    Map<String, String> paramMap = new HashMap<>();
+    paramMap.put("matchId", matchId);
+    paramMap.put("puuid", puuid);
+    given(matchGameAddInfoMapper.selectMatchGameUseRunes(paramMap))
+        .willReturn(mockReturnList);
+
+    ResponseDto result = matchGameAddInfoService.getMatchUseRunList(matchId, puuid);
+    List<MatchGameBansDto> resultList = (List<MatchGameBansDto>) result.getResult();
+    assertThat(result.getResultCode()).isEqualTo(HttpStatus.OK.value());
+    assertThat(resultList.size() > 0).isTrue();
+  }
+
+  @Test
+  @DisplayName("게임에서 사용한 특정 유저의 룬정보 조회시 DB에 존재하지 않는 MatchId, Puuid인 경우 NotFound를 획득 한다.")
+  void getMatchUseRuneList_ReturnNotFound() {
+    ArrayList<MatchGameBansDto> mockReturnList = new ArrayList<>();
+    String matchId = "KR_6064599598";
+
+    given(matchGameAddInfoMapper.selectMatchGameBanList(matchId))
+        .willReturn(mockReturnList);
+
+    ResponseDto result = matchGameAddInfoService.getMatchBanList(matchId);
+    assertThat(result.getResultCode()).isEqualTo(HttpStatus.NOT_FOUND.value());
+  }
+}

--- a/src/test/java/com/nooblol/account/service/impl/MatchGameAddInfoServiceImplTest.java
+++ b/src/test/java/com/nooblol/account/service/impl/MatchGameAddInfoServiceImplTest.java
@@ -1,7 +1,7 @@
 package com.nooblol.account.service.impl;
 
 import static org.assertj.core.api.Assertions.*;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.BDDMockito.*;
 
 import com.nooblol.account.dto.match.MatchGameBansDto;
@@ -9,14 +9,12 @@ import com.nooblol.account.dto.match.MatchGameParticipantsDto;
 import com.nooblol.account.dto.match.MatchUseRuneDto;
 import com.nooblol.account.mapper.MatchGameAddInfoMapper;
 import com.nooblol.account.service.MatchGameAddInfoService;
-import com.nooblol.global.dto.ResponseDto;
 import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.springframework.http.HttpStatus;
 
 class MatchGameAddInfoServiceImplTest {
 
@@ -31,7 +29,7 @@ class MatchGameAddInfoServiceImplTest {
   }
 
   @Test
-  @DisplayName("모든 참가자 정보 조회시 DB에 존재하는 MatchId인 경우 OK상태값을 획득 한다.")
+  @DisplayName("모든 참가자 정보 조회시 DB에 존재하는 MatchId인 경우, 참가자 정보에 대한 List를 획득한다")
   void matchAllParticipantsList_ListReturnOkTest() {
     ArrayList<MatchGameParticipantsDto> mockReturnList = new ArrayList<>();
     String matchId = "KR_6064599598";
@@ -56,14 +54,15 @@ class MatchGameAddInfoServiceImplTest {
     when(matchGameAddInfoMapper.selectMatchAllParticipantsListByMatchId(matchId))
         .thenReturn(mockReturnList);
 
-    ResponseDto result = matchGameAddInfoService.getMatchAllParticipantsList(matchId);
-    List<MatchGameParticipantsDto> resultList = (List<MatchGameParticipantsDto>) result.getResult();
-    assertThat(result.getResultCode()).isEqualTo(HttpStatus.OK.value());
-    assertThat(resultList.size() > 0).isTrue();
+    List<MatchGameParticipantsDto> result =
+        matchGameAddInfoService.getMatchAllParticipantsList(matchId);
+
+    assertThat(result.size() > 0).isTrue();
+    assertEquals(mockReturnList, result);
   }
 
   @Test
-  @DisplayName("모든 참가자 정보 조회시 DB에 존재하지 않는 MatchId인 경우 NotFound를 획득 한다.")
+  @DisplayName("모든 참가자 정보 조회시 DB에 존재하지 않는 MatchId인 경우 빈 List를 획득 한다.")
   void matchAllParticipantsList_ReturnNotFound() {
     ArrayList<MatchGameParticipantsDto> mockReturnList = new ArrayList<>();
     String matchId = "KR_6064599598";
@@ -71,12 +70,14 @@ class MatchGameAddInfoServiceImplTest {
     given(matchGameAddInfoMapper.selectMatchAllParticipantsListByMatchId(matchId))
         .willReturn(mockReturnList);
 
-    ResponseDto result = matchGameAddInfoService.getMatchAllParticipantsList(matchId);
-    assertThat(result.getResultCode()).isEqualTo(HttpStatus.NOT_FOUND.value());
+    List<MatchGameParticipantsDto> result =
+        matchGameAddInfoService.getMatchAllParticipantsList(matchId);
+
+    assertEquals(result.size(), 0);
   }
 
   @Test
-  @DisplayName("게임의 벤이된 챔피언리스트 조회시 DB에 존재하는 MatchId인 경우 OK상태값을 획득 한다.")
+  @DisplayName("게임의 벤이된 챔피언리스트 조회시 DB에 존재하는 MatchId인 경우 벤한 챔피언의 List를 획득 한다.")
   void matchBanList_ListReturnOkTest() {
     ArrayList<MatchGameBansDto> mockReturnList = new ArrayList<>();
     String matchId = "KR_6064599598";
@@ -101,14 +102,13 @@ class MatchGameAddInfoServiceImplTest {
     given(matchGameAddInfoMapper.selectMatchGameBanList(matchId))
         .willReturn(mockReturnList);
 
-    ResponseDto result = matchGameAddInfoService.getMatchBanList(matchId);
-    List<MatchGameBansDto> resultList = (List<MatchGameBansDto>) result.getResult();
-    assertThat(result.getResultCode()).isEqualTo(HttpStatus.OK.value());
-    assertThat(resultList.size() > 0).isTrue();
+    List<MatchGameBansDto> result = matchGameAddInfoService.getMatchBanList(matchId);
+
+    assertEquals(result, mockReturnList);
   }
 
   @Test
-  @DisplayName("게임의 벤이된 챔피언리스트 조회시 DB에 존재하지 않는 MatchId인 경우 NotFound를 획득 한다.")
+  @DisplayName("게임의 벤이된 챔피언리스트 조회시 DB에 존재하지 않는 MatchId인 경우 빈 List를 획득 한다.")
   void matchBanList_ReturnNotFound() {
     ArrayList<MatchGameBansDto> mockReturnList = new ArrayList<>();
     String matchId = "KR_6064599598";
@@ -116,12 +116,12 @@ class MatchGameAddInfoServiceImplTest {
     given(matchGameAddInfoMapper.selectMatchGameBanList(matchId))
         .willReturn(mockReturnList);
 
-    ResponseDto result = matchGameAddInfoService.getMatchBanList(matchId);
-    assertThat(result.getResultCode()).isEqualTo(HttpStatus.NOT_FOUND.value());
+    List<MatchGameBansDto> result = matchGameAddInfoService.getMatchBanList(matchId);
+    assertEquals(result.size(), 0);
   }
 
   @Test
-  @DisplayName("게임에서 사용한 특정 유저의 룬정보 조회시 DB에 존재하는 MatchId, Puuid인 경우 OK상태값을 획득 한다.")
+  @DisplayName("게임에서 사용한 특정 유저의 룬정보 조회시 DB에 존재하는 MatchId, Puuid인 경우 사용한 룬정보 List를 획득 한다.")
   void getMatchUseRuneList_ListReturnOkTest() {
     ArrayList<MatchUseRuneDto> mockReturnList = new ArrayList<>();
     String matchId = "KR_6064599598";
@@ -148,22 +148,22 @@ class MatchGameAddInfoServiceImplTest {
     given(matchGameAddInfoMapper.selectMatchGameUseRunes(puuid, matchId))
         .willReturn(mockReturnList);
 
-    ResponseDto result = matchGameAddInfoService.getMatchUseRunList(matchId, puuid);
-    List<MatchGameBansDto> resultList = (List<MatchGameBansDto>) result.getResult();
-    assertThat(result.getResultCode()).isEqualTo(HttpStatus.OK.value());
-    assertThat(resultList.size() > 0).isTrue();
+    List<MatchUseRuneDto> result = matchGameAddInfoService.getMatchUseRunList(matchId, puuid);
+    assertEquals(result, mockReturnList);
   }
 
   @Test
-  @DisplayName("게임에서 사용한 특정 유저의 룬정보 조회시 DB에 존재하지 않는 MatchId, Puuid인 경우 NotFound를 획득 한다.")
+  @DisplayName("게임에서 사용한 특정 유저의 룬정보 조회시 DB에 존재하지 않는 MatchId, Puuid인 경우 빈 리스트를  획득 한다.")
   void getMatchUseRuneList_ReturnNotFound() {
-    ArrayList<MatchGameBansDto> mockReturnList = new ArrayList<>();
+    ArrayList<MatchUseRuneDto> mockReturnList = new ArrayList<>();
     String matchId = "KR_6064599598";
+    String puuid = "Test_Puuid";
 
-    given(matchGameAddInfoMapper.selectMatchGameBanList(matchId))
+    given(matchGameAddInfoMapper.selectMatchGameUseRunes(puuid, matchId))
         .willReturn(mockReturnList);
 
-    ResponseDto result = matchGameAddInfoService.getMatchBanList(matchId);
-    assertThat(result.getResultCode()).isEqualTo(HttpStatus.NOT_FOUND.value());
+    List<MatchUseRuneDto> result = matchGameAddInfoService.getMatchUseRunList(matchId, puuid);
+
+    assertEquals(result, mockReturnList);
   }
 }

--- a/src/test/java/com/nooblol/account/service/impl/MatchGameInfoServiceImplTest.java
+++ b/src/test/java/com/nooblol/account/service/impl/MatchGameInfoServiceImplTest.java
@@ -1,6 +1,7 @@
 package com.nooblol.account.service.impl;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.when;
 
 
@@ -19,9 +20,7 @@ import com.nooblol.account.service.MatchGameListService;
 import com.nooblol.global.config.RiotConfiguration;
 import com.nooblol.global.dto.ResponseDto;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -196,16 +195,14 @@ class MatchGameInfoServiceImplTest {
     mockReturnList.add(mockSample1);
     mockReturnList.add(mockSample2);
 
-    Map<String, Object> searchParam = new HashMap<>();
-    searchParam.put("puuid", responseOkPuuid);
-    searchParam.put("pageNum", 0);
-    searchParam.put("limitNum", 30);
 
-    when(matchGameAddInfoMapper.selectMatchSimpleList(searchParam)).thenReturn(
+    //정상적인 MatchSearchDto로 테스트 하고 싶었으나, 객체가 달라 오류가 발생함. any로 대체
+    when(matchGameAddInfoMapper.selectMatchSimpleList(any())).thenReturn(
         (ArrayList<MatchGameSimpleDto>) mockReturnList);
 
-    List<MatchGameSimpleDto> returnList = (List<MatchGameSimpleDto>) matchGameInfoService.getMatchInfoListByPuuid(
-        responseOkPuuid, 0, 30).getResult();
+    List<MatchGameSimpleDto> returnList =
+        (List<MatchGameSimpleDto>) matchGameInfoService.getMatchInfoListByPuuid(
+            responseOkPuuid, 0, 30).getResult();
 
     assertEquals(returnList, mockReturnList);
   }


### PR DESCRIPTION
전적 데이터 파싱에 대한 마지막 PR입니다.

[#17 ] 에 대한 구현 기능입니다.

1.  MatchId 전달받아 해당 게임에 참여한 모든 사용자를 조회후 Response
2. MatchId만 전달받아 해당 게임에서 벤이된 챔피언을 Response
3. MatchId와 Puuid를 전달받아 해당 게임 해당 사용자가 사용한 룬의 정보를 Response